### PR TITLE
reactのcss-in-jsであるemotionの追加

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,12 +16,12 @@
             "DOM",
             "ES2020"
         ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
-        "jsx": "react" /* Specify what JSX code is generated. */,
+        "jsx": "react-jsx" /* Specify what JSX code is generated. */,
         // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
         // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
         // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
         // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-        // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
+        "jsxImportSource": "@emotion/react" /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */,
         // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
         // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
         // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
@@ -34,7 +34,9 @@
         // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
         // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
         // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
-        // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+        "types": [
+            "@emotion/react/types/css-prop"
+        ] /* Specify type package names to be included without being referenced in a source file. */,
         // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
         // "resolveJsonModule": true,                        /* Enable importing .json files */
         // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */


### PR DESCRIPTION
### emotion使う理由
- emotionだと疑似要素やkeyframeが使える
- パフォーマンス改善(styleフロップは公式でも一応非推奨)

### emotionの使い方
```tsx
const styleName = css({
  fontSize: '20px',
  padding: '32px',
  '&:hover': {
    backgroundColor: 'cyan',
  },
})

return (
  <button css={styleName}>
    button text
  </button>
)
```