### PR TITLE
疑似要素エリアの挙動をコードエリアに反映する処理の追加

### DIFF
--- a/src/components/codeArea/CodeArea.tsx
+++ b/src/components/codeArea/CodeArea.tsx
@@ -9,7 +9,7 @@ export const CodeArea = () => {
             width={'30rem'}
             height={'15rem'}
             bg={'white'}
-            borderRadius={'2rem'}
+            borderLeftRadius={'2rem'}
             flexDirection={'row'}
             overflowY={'scroll'}
             overflowX={'hidden'}

--- a/src/components/codeArea/cssRenderingArea/CssRenderingArea.tsx
+++ b/src/components/codeArea/cssRenderingArea/CssRenderingArea.tsx
@@ -1,58 +1,50 @@
 import { Flex, Text } from '@chakra-ui/react'
 import React from 'react'
 import { useAppSelector } from '../../../hooks'
-import { defaultButtonCss } from '../defaultButtonCss'
+import { getElementUid } from '../../pseudoArea/pseudoAreaSlice'
 
+const transformCssLowerCase = (cssProp: string) => {
+    return cssProp
+        .split(/(?=[A-Z])/)
+        .map((item) => item.toLowerCase())
+        .join('-')
+}
 export const CssRenderingArea = () => {
-    const width = useAppSelector((state) => state.buttonView.width)
-    const isDisplayWidth = defaultButtonCss.width === 'ALWAYS' || defaultButtonCss.width !== width
-    const height = useAppSelector((state) => state.buttonView.height)
-    const isDisplayHeight = defaultButtonCss.height === 'ALWAYS' || defaultButtonCss.height !== height
-    const color = useAppSelector((state) => state.buttonView.color)
-    const isDisplayColor = defaultButtonCss.color === 'ALWAYS' || defaultButtonCss.color !== color
-    const backgroundColor = useAppSelector((state) => state.buttonView.backgroundColor)
-    const isDisplayBackgroundColor =
-        defaultButtonCss.backgroundColor === 'ALWAYS' || defaultButtonCss.backgroundColor !== backgroundColor
-    const border = useAppSelector((state) => state.buttonView.border)
-    const isDisplayBorder = defaultButtonCss.border === 'ALWAYS' || defaultButtonCss.border !== border
-    const padding = useAppSelector((state) => state.buttonView.padding)
-    const isDisplayPadding = defaultButtonCss.padding === 'ALWAYS' || defaultButtonCss.padding !== padding
-    const textDecoration = useAppSelector((state) => state.buttonView.textDecoration)
-    const isDisplayTextDecoration =
-        defaultButtonCss.textDecoration === 'ALWAYS' || defaultButtonCss.textDecoration !== textDecoration
-    const display = useAppSelector((state) => state.buttonView.display)
-    const isDisplayDisplay = defaultButtonCss.display === 'ALWAYS' || defaultButtonCss.display !== display
-    const fontSize = useAppSelector((state) => state.buttonView.fontSize)
-    const isDisplayFontSize = defaultButtonCss.fontSize === 'ALWAYS' || defaultButtonCss.fontSize !== fontSize
-    const borderColor = useAppSelector((state) => state.buttonView.borderColor)
-    const isDisplayBorderColor =
-        defaultButtonCss.borderColor === 'ALWAYS' || defaultButtonCss.borderColor !== borderColor
-    const borderStyle = useAppSelector((state) => state.buttonView.borderStyle)
-    const isDisplayBorderStyle =
-        defaultButtonCss.borderStyle === 'ALWAYS' || defaultButtonCss.borderStyle !== borderStyle
-    const borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
-    const isDisplayBorderWidth =
-        defaultButtonCss.borderWidth === 'ALWAYS' || defaultButtonCss.borderWidth !== borderWidth
-    const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
-    const isDisplayBorderRadius =
-        defaultButtonCss.borderRadius === 'ALWAYS' || defaultButtonCss.borderRadius !== borderRadius
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    class HTMLBuilder {
+        buildHeader = (elementName: string, elementClass: string[]) => {
+            const _elementName = elementName === 'Main' ? '' : '::' + elementName
+            const _elementClass = elementClass.length === 0 ? '' : ':' + elementClass.join(':')
+            const resultStr = '.custom_button' + _elementName + _elementClass + ' {'
+            return <Text>{resultStr}</Text>
+        }
+
+        buildContent = (elementName: string, elementClass: string[]) => {
+            const uid = getElementUid(elementName, elementClass)
+            const codes = cssStates[uid].cssCodes
+            const resultStr = []
+            for (const [key, value] of Object.entries(codes)) {
+                resultStr.push(transformCssLowerCase(key) + ': ' + value)
+            }
+            return resultStr.map((str) => {
+                return <Text key={str}>&emsp;{str}</Text>
+            })
+        }
+    }
+    const constructHtml = (builder: typeof HTMLBuilder, elementName: string, elementClass: string[]) => {
+        return (
+            <>
+                {new builder().buildHeader(elementName, elementClass)}
+                {new builder().buildContent(elementName, elementClass)}
+                <Text>{'}'}</Text>
+            </>
+        )
+    }
     return (
         <Flex flexDirection={'column'} color={'black'} fontSize={'1rem'} margin={'1rem'}>
-            <Text>.custom_button {'{'}</Text>
-            {isDisplayWidth && <Text>&emsp;width: {width}</Text>}
-            {isDisplayHeight && <Text>&emsp;height: {height}</Text>}
-            {isDisplayColor && <Text>&emsp;color: {color}</Text>}
-            {isDisplayBackgroundColor && <Text>&emsp;background-color: {backgroundColor}</Text>}
-            {isDisplayBorder && <Text>&emsp;border: {border}</Text>}
-            {isDisplayPadding && <Text>&emsp;padding: {padding}</Text>}
-            {isDisplayTextDecoration && <Text>&emsp;text-decoration: {textDecoration}</Text>}
-            {isDisplayDisplay && <Text>&emsp;display: {display}</Text>}
-            {isDisplayFontSize && <Text>&emsp;font-size: {fontSize}</Text>}
-            {isDisplayBorderColor && <Text>&emsp;border-color: {borderColor}</Text>}
-            {isDisplayBorderStyle && <Text>&emsp;border-style: {borderStyle}</Text>}
-            {isDisplayBorderWidth && <Text>&emsp;border-width: {borderWidth}</Text>}
-            {isDisplayBorderRadius && <Text>&emsp;border-radius: {borderRadius}</Text>}
-            <Text>{'}'}</Text>
+            {Object.values(cssStates).map((cssState) => {
+                return constructHtml(HTMLBuilder, cssState.elementName, cssState.classNames)
+            })}
         </Flex>
     )
 }

--- a/src/components/copyButton/CopyButton.tsx
+++ b/src/components/copyButton/CopyButton.tsx
@@ -77,6 +77,7 @@ export const CopyButton = () => {
             alignItems={'center'}
             borderRadius={'20%'}
             bg={'black'}
+            zIndex={100}
             initial={copyAnimeVariants.init}
             whileHover={isCopy ? copyAnimeVariants.whileHoverOut : copyAnimeVariants.whileHover}
             whileTap={copyAnimeVariants.whileTap}

--- a/src/components/cssCustomArea/CssCustomArea.tsx
+++ b/src/components/cssCustomArea/CssCustomArea.tsx
@@ -37,16 +37,16 @@ export const CssCustomArea = () => {
             >
                 Basics
             </Text>
-            <CustomAreaButton text="Width" isDisplay={displayWidth} setter={setDisplayWidth} />
-            <CustomAreaButton text="Height" isDisplay={displayHeight} setter={setDisplayHeight} />
-            <CustomAreaButton text="Color" isDisplay={displayColor} setter={setDisplayColor} />
+            <CustomAreaButton text="width" isDisplay={displayWidth} setter={setDisplayWidth} />
+            <CustomAreaButton text="height" isDisplay={displayHeight} setter={setDisplayHeight} />
+            <CustomAreaButton text="color" isDisplay={displayColor} setter={setDisplayColor} />
             <CustomAreaButton
-                text="BackgroundColor"
+                text="backgroundColor"
                 isDisplay={displayBackgroundColor}
                 setter={setDisplayBackgroundColor}
             />
-            <CustomAreaButton text="FontSize" isDisplay={displayFontSize} setter={setDisplayFontSize} />
-            <CustomAreaButton text="Padding" isDisplay={displayPadding} setter={setDisplayPadding} />
+            <CustomAreaButton text="fontSize" isDisplay={displayFontSize} setter={setDisplayFontSize} />
+            <CustomAreaButton text="padding" isDisplay={displayPadding} setter={setDisplayPadding} />
             <Text
                 display={'flex'}
                 alignItems={'center'}
@@ -56,10 +56,10 @@ export const CssCustomArea = () => {
             >
                 Border
             </Text>
-            <CustomAreaButton text="BorderColor" isDisplay={displayBorderColor} setter={setDisplayBorderColor} />
-            <CustomAreaButton text="BorderStyle" isDisplay={displayBorderStyle} setter={setDisplayBorderStyle} />
-            <CustomAreaButton text="BorderWidth" isDisplay={displayBorderWidth} setter={setDisplayBorderWidth} />
-            <CustomAreaButton text="BorderRadius" isDisplay={displayBorderRadius} setter={setDisplayBorderRadius} />
+            <CustomAreaButton text="borderColor" isDisplay={displayBorderColor} setter={setDisplayBorderColor} />
+            <CustomAreaButton text="borderStyle" isDisplay={displayBorderStyle} setter={setDisplayBorderStyle} />
+            <CustomAreaButton text="borderWidth" isDisplay={displayBorderWidth} setter={setDisplayBorderWidth} />
+            <CustomAreaButton text="borderRadius" isDisplay={displayBorderRadius} setter={setDisplayBorderRadius} />
         </Flex>
     )
 }

--- a/src/components/cssCustomArea/CustomAreaButton.tsx
+++ b/src/components/cssCustomArea/CustomAreaButton.tsx
@@ -1,9 +1,12 @@
-import React, { memo } from 'react'
+import React, { memo, useEffect, useRef } from 'react'
 import { Button, Flex, Text } from '@chakra-ui/react'
 import { ActionCreatorWithPayload } from '@reduxjs/toolkit'
 import { ChatIcon } from '@chakra-ui/icons'
-import { useAppDispatch } from '../../hooks'
+import { useAppDispatch, useAppSelector } from '../../hooks'
 import { customButtonStyle } from './initStyle'
+import { removeCurrentCssCodes, saveCurrentCssCodes, saveCurrentCustomAreaDisplay } from '../pseudoArea/pseudoAreaSlice'
+import { getAllCssProps } from '../buttonView/buttonViewSlice'
+import { getAllDisplayStatus } from './cssCustomAreaSlice'
 
 type propsType = {
     text: string
@@ -12,7 +15,49 @@ type propsType = {
 }
 
 export const CustomAreaButton = memo(({ text, isDisplay, setter }: propsType) => {
+    const isFirstRender = useRef(true)
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent)
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent)
     const dispatch = useAppDispatch()
+    const allCustomDisplayStatus = useAppSelector((state) => getAllDisplayStatus(state))
+    const currentAllCssProps = useAppSelector((state) => getAllCssProps(state))
+    useEffect(() => {
+        if (isFirstRender.current) {
+            isFirstRender.current = false
+            return
+        }
+        let cssVal = ''
+        for (const [key, value] of Object.entries(currentAllCssProps)) {
+            if (key === text) {
+                cssVal = value
+            }
+        }
+        if (isDisplay) {
+            dispatch(
+                saveCurrentCssCodes({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssProp: text,
+                    cssValue: cssVal,
+                })
+            )
+        } else {
+            dispatch(
+                removeCurrentCssCodes({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssProp: text,
+                })
+            )
+        }
+        dispatch(
+            saveCurrentCustomAreaDisplay({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                allCustomAreaDisplayStatus: allCustomDisplayStatus,
+            })
+        )
+    }, [isDisplay])
     return (
         <Flex flexDirection={'column'} justifyContent={'space-around'} width={customButtonStyle.width}>
             <Button

--- a/src/components/cssEditArea/backgroundColor/EditBackgroundColor.tsx
+++ b/src/components/cssEditArea/backgroundColor/EditBackgroundColor.tsx
@@ -4,11 +4,15 @@ import { motion } from 'framer-motion'
 import React, { useState } from 'react'
 import { AlphaPicker, ChromePicker, ColorResult, HuePicker } from 'react-color'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setBackgroundColor } from '../../buttonView/buttonViewSlice'
+import { getAllCssProps, setBackgroundColor } from '../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
 import { rotateElementVariants } from '../animation/rotateElement'
 
 export const EditBackgroundColor = () => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const backgroundColor = useAppSelector((state) => state.buttonView.backgroundColor)
     const displayBackgroundColor = useAppSelector((state) => state.cssCustomArea.displayBackgroundColor)
@@ -16,6 +20,22 @@ export const EditBackgroundColor = () => {
     const handleChange = (color: ColorResult) => {
         const rgba = `rgba(${color.rgb.r},${color.rgb.g},${color.rgb.b},${color.rgb.a})`
         dispatch(setBackgroundColor(rgba))
+        const newAllCssProps = { ...allCssProps, backgroundColor: rgba }
+        dispatch(
+            saveCurrentCssProps({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                allCssProps: newAllCssProps,
+            })
+        )
+        dispatch(
+            saveCurrentCssCodes({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                cssProp: 'backgroundColor',
+                cssValue: rgba,
+            })
+        )
     }
     return (
         <>

--- a/src/components/cssEditArea/borderColor/EditBorderColor.tsx
+++ b/src/components/cssEditArea/borderColor/EditBorderColor.tsx
@@ -4,11 +4,15 @@ import { motion } from 'framer-motion'
 import React, { useState } from 'react'
 import { AlphaPicker, ChromePicker, ColorResult, HuePicker } from 'react-color'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setBorderColor } from '../../buttonView/buttonViewSlice'
+import { getAllCssProps, setBorderColor } from '../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
 import { rotateElementVariants } from '../animation/rotateElement'
 
 export const EditBorderColor = () => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const borderColor = useAppSelector((state) => state.buttonView.borderColor)
     const displayBorderColor = useAppSelector((state) => state.cssCustomArea.displayBorderColor)
@@ -16,6 +20,22 @@ export const EditBorderColor = () => {
     const handleChange = (color: ColorResult) => {
         const rgba = `rgba(${color.rgb.r},${color.rgb.g},${color.rgb.b},${color.rgb.a})`
         dispatch(setBorderColor(rgba))
+        const newAllCssProps = { ...allCssProps, borderColor: rgba }
+        dispatch(
+            saveCurrentCssProps({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                allCssProps: newAllCssProps,
+            })
+        )
+        dispatch(
+            saveCurrentCssCodes({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                cssProp: 'borderColor',
+                cssValue: rgba,
+            })
+        )
     }
     return (
         <Flex>

--- a/src/components/cssEditArea/borderRadius/EditBorderRadius.tsx
+++ b/src/components/cssEditArea/borderRadius/EditBorderRadius.tsx
@@ -14,7 +14,8 @@ import {
 import { motion } from 'framer-motion'
 import React, { useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setBorderRadius } from '../../buttonView/buttonViewSlice'
+import { getAllCssProps, setBorderRadius } from '../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
 import { rotateElementVariants } from '../animation/rotateElement'
 import { EditBorderRadiusBottomLeftHorizontal } from './bottomLeft/EditBorderRadiusBottomLeftHorizontal'
@@ -27,7 +28,10 @@ import { EditBorderRadiusTopRightHorizontal } from './topRight/EditBorderRadiusT
 import { EditBorderRadiusTopRightVertical } from './topRight/EditBorderRadiusTopRightVertical'
 
 export const EditBorderRadius = () => {
-    // TODO:デザインは一旦ポイ
+    // TODO:親のborderRadiusだけ他疑似要素に変更時見た目を保持していない（データは保持できている）
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
     const displayBorderRadius = useAppSelector((state) => state.cssCustomArea.displayBorderRadius)
@@ -39,6 +43,22 @@ export const EditBorderRadius = () => {
     const onChangeValue = (v: number) => {
         setBorderRadiusAll(v.toString() + 'px')
         dispatch(setBorderRadius(v.toString() + 'px'))
+        const newAllCssProps = { ...allCssProps, borderRadius: v.toString() + 'px' }
+        dispatch(
+            saveCurrentCssProps({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                allCssProps: newAllCssProps,
+            })
+        )
+        dispatch(
+            saveCurrentCssCodes({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                cssProp: 'borderRadius',
+                cssValue: v.toString() + 'px',
+            })
+        )
     }
     return (
         <>

--- a/src/components/cssEditArea/borderRadius/bottomLeft/EditBorderRadiusBottomLeftHorizontal.tsx
+++ b/src/components/cssEditArea/borderRadius/bottomLeft/EditBorderRadiusBottomLeftHorizontal.tsx
@@ -1,9 +1,13 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
+import { getAllCssProps, setBorderRadius } from '../../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusBottomLeftHorizontal = memo(() => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
     const [showTooltipBottomLeftHorizontal, setShowTooltipBottomLeftHorizontal] = useState(false)
@@ -21,6 +25,22 @@ export const EditBorderRadiusBottomLeftHorizontal = memo(() => {
             borderRadiusList[3] = v.toString() + 'px'
             borderRadiusList.splice(4, 0, '/')
             dispatch(setBorderRadius(borderRadiusList.join(' ')))
+            const newAllCssProps = { ...allCssProps, borderRadius: borderRadiusList.join(' ') }
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    allCssProps: newAllCssProps,
+                })
+            )
+            dispatch(
+                saveCurrentCssCodes({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssProp: 'borderRadius',
+                    cssValue: borderRadiusList.join(' '),
+                })
+            )
         } else {
             dispatch(
                 setBorderRadius(

--- a/src/components/cssEditArea/borderRadius/bottomLeft/EditBorderRadiusBottomLeftVertical.tsx
+++ b/src/components/cssEditArea/borderRadius/bottomLeft/EditBorderRadiusBottomLeftVertical.tsx
@@ -1,9 +1,13 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
+import { getAllCssProps, setBorderRadius } from '../../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusBottomLeftVertical = memo(() => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
     const [showTooltipBottomLeftVertical, setShowTooltipBottomLeftVertical] = useState(false)
@@ -21,6 +25,22 @@ export const EditBorderRadiusBottomLeftVertical = memo(() => {
             borderRadiusList[7] = v.toString() + 'px'
             borderRadiusList.splice(4, 0, '/')
             dispatch(setBorderRadius(borderRadiusList.join(' ')))
+            const newAllCssProps = { ...allCssProps, borderRadius: borderRadiusList.join(' ') }
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    allCssProps: newAllCssProps,
+                })
+            )
+            dispatch(
+                saveCurrentCssCodes({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssProp: 'borderRadius',
+                    cssValue: borderRadiusList.join(' '),
+                })
+            )
         } else {
             dispatch(
                 setBorderRadius(

--- a/src/components/cssEditArea/borderRadius/bottomRight/EditBorderRadiusBottomRightHorizontal.tsx
+++ b/src/components/cssEditArea/borderRadius/bottomRight/EditBorderRadiusBottomRightHorizontal.tsx
@@ -1,9 +1,13 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
+import { getAllCssProps, setBorderRadius } from '../../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusBottomRightHorizontal = memo(() => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
     const [showTooltipBottomRightHorizontal, setShowTooltipBottomRightHorizontal] = useState(false)
@@ -21,6 +25,22 @@ export const EditBorderRadiusBottomRightHorizontal = memo(() => {
             borderRadiusList[2] = v.toString() + 'px'
             borderRadiusList.splice(4, 0, '/')
             dispatch(setBorderRadius(borderRadiusList.join(' ')))
+            const newAllCssProps = { ...allCssProps, borderRadius: borderRadiusList.join(' ') }
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    allCssProps: newAllCssProps,
+                })
+            )
+            dispatch(
+                saveCurrentCssCodes({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssProp: 'borderRadius',
+                    cssValue: borderRadiusList.join(' '),
+                })
+            )
         } else {
             dispatch(
                 setBorderRadius(

--- a/src/components/cssEditArea/borderRadius/bottomRight/EditBorderRadiusBottomRightVertical.tsx
+++ b/src/components/cssEditArea/borderRadius/bottomRight/EditBorderRadiusBottomRightVertical.tsx
@@ -1,9 +1,13 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
+import { getAllCssProps, setBorderRadius } from '../../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusBottomRightVertical = memo(() => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
     const [showTooltipBottomRightVertical, setShowTooltipBottomRightVertical] = useState(false)
@@ -21,6 +25,22 @@ export const EditBorderRadiusBottomRightVertical = memo(() => {
             borderRadiusList[6] = v.toString() + 'px'
             borderRadiusList.splice(4, 0, '/')
             dispatch(setBorderRadius(borderRadiusList.join(' ')))
+            const newAllCssProps = { ...allCssProps, borderRadius: borderRadiusList.join(' ') }
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    allCssProps: newAllCssProps,
+                })
+            )
+            dispatch(
+                saveCurrentCssCodes({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssProp: 'borderRadius',
+                    cssValue: borderRadiusList.join(' '),
+                })
+            )
         } else {
             dispatch(
                 setBorderRadius(

--- a/src/components/cssEditArea/borderRadius/topLeft/EditBorderRadiusTopLeftHorizontal.tsx
+++ b/src/components/cssEditArea/borderRadius/topLeft/EditBorderRadiusTopLeftHorizontal.tsx
@@ -1,9 +1,13 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
+import { getAllCssProps, setBorderRadius } from '../../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusTopLeftHorizontal = memo(() => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
     const [showTooltipTopLeftHorizontal, setShowTooltipTopLeftHorizontal] = useState(false)
@@ -21,6 +25,22 @@ export const EditBorderRadiusTopLeftHorizontal = memo(() => {
             borderRadiusList[0] = v.toString() + 'px'
             borderRadiusList.splice(4, 0, '/')
             dispatch(setBorderRadius(borderRadiusList.join(' ')))
+            const newAllCssProps = { ...allCssProps, borderRadius: borderRadiusList.join(' ') }
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    allCssProps: newAllCssProps,
+                })
+            )
+            dispatch(
+                saveCurrentCssCodes({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssProp: 'borderRadius',
+                    cssValue: borderRadiusList.join(' '),
+                })
+            )
         } else {
             dispatch(
                 setBorderRadius(

--- a/src/components/cssEditArea/borderRadius/topLeft/EditBorderRadiusTopLeftVertical.tsx
+++ b/src/components/cssEditArea/borderRadius/topLeft/EditBorderRadiusTopLeftVertical.tsx
@@ -1,9 +1,13 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
+import { getAllCssProps, setBorderRadius } from '../../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusTopLeftVertical = memo(() => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
     const [showTooltipTopLeftVertical, setShowTooltipTopLeftVertical] = useState(false)
@@ -21,6 +25,22 @@ export const EditBorderRadiusTopLeftVertical = memo(() => {
             borderRadiusList[4] = v.toString() + 'px'
             borderRadiusList.splice(4, 0, '/')
             dispatch(setBorderRadius(borderRadiusList.join(' ')))
+            const newAllCssProps = { ...allCssProps, borderRadius: borderRadiusList.join(' ') }
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    allCssProps: newAllCssProps,
+                })
+            )
+            dispatch(
+                saveCurrentCssCodes({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssProp: 'borderRadius',
+                    cssValue: borderRadiusList.join(' '),
+                })
+            )
         } else {
             dispatch(
                 setBorderRadius(

--- a/src/components/cssEditArea/borderRadius/topRight/EditBorderRadiusTopRightHorizontal.tsx
+++ b/src/components/cssEditArea/borderRadius/topRight/EditBorderRadiusTopRightHorizontal.tsx
@@ -1,9 +1,13 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
+import { getAllCssProps, setBorderRadius } from '../../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusTopRightHorizontal = memo(() => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
     const [showTooltipTopRightHorizontal, setShowTooltipTopRightHorizontal] = useState(false)
@@ -21,6 +25,22 @@ export const EditBorderRadiusTopRightHorizontal = memo(() => {
             borderRadiusList[1] = v.toString() + 'px'
             borderRadiusList.splice(4, 0, '/')
             dispatch(setBorderRadius(borderRadiusList.join(' ')))
+            const newAllCssProps = { ...allCssProps, borderRadius: borderRadiusList.join(' ') }
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    allCssProps: newAllCssProps,
+                })
+            )
+            dispatch(
+                saveCurrentCssCodes({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssProp: 'borderRadius',
+                    cssValue: borderRadiusList.join(' '),
+                })
+            )
         } else {
             dispatch(
                 setBorderRadius(

--- a/src/components/cssEditArea/borderRadius/topRight/EditBorderRadiusTopRightVertical.tsx
+++ b/src/components/cssEditArea/borderRadius/topRight/EditBorderRadiusTopRightVertical.tsx
@@ -1,9 +1,13 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
+import { getAllCssProps, setBorderRadius } from '../../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusTopRightVertical = memo(() => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
     const [showTooltipTopRightVertical, setShowTooltipTopRightVertical] = useState(false)
@@ -21,6 +25,22 @@ export const EditBorderRadiusTopRightVertical = memo(() => {
             borderRadiusList[5] = v.toString() + 'px'
             borderRadiusList.splice(4, 0, '/')
             dispatch(setBorderRadius(borderRadiusList.join(' ')))
+            const newAllCssProps = { ...allCssProps, borderRadius: borderRadiusList.join(' ') }
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    allCssProps: newAllCssProps,
+                })
+            )
+            dispatch(
+                saveCurrentCssCodes({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssProp: 'borderRadius',
+                    cssValue: borderRadiusList.join(' '),
+                })
+            )
         } else {
             dispatch(
                 setBorderRadius(

--- a/src/components/cssEditArea/borderStyle/EditBorderStyle.tsx
+++ b/src/components/cssEditArea/borderStyle/EditBorderStyle.tsx
@@ -3,16 +3,39 @@ import { Flex, Button, Box, Text } from '@chakra-ui/react'
 import { motion } from 'framer-motion'
 import React, { useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setBorderStyle } from '../../buttonView/buttonViewSlice'
+import { getAllCssProps, setBorderStyle } from '../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
 import { rotateElementVariants } from '../animation/rotateElement'
 
 export const EditBorderStyle = () => {
-    // TODO:Animationはスーパーてきとー
+    // TODO:でかすぎ
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const borderStyle = useAppSelector((state) => state.buttonView.borderStyle)
     const displayBorderStyle = useAppSelector((state) => state.cssCustomArea.displayBorderStyle)
     const [isDisplayDetail, setIsDisplayDetail] = useState(false)
+    const onClickBorderStyle = (style: string) => {
+        dispatch(setBorderStyle(style))
+        const newAllCssProps = { ...allCssProps, borderStyle: style }
+        dispatch(
+            saveCurrentCssProps({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                allCssProps: newAllCssProps,
+            })
+        )
+        dispatch(
+            saveCurrentCssCodes({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                cssProp: 'borderStyle',
+                cssValue: style,
+            })
+        )
+    }
     const confirmClickedBorderStyleButton = (_borderStyle: string, position: string) => {
         const borderStyleList = borderStyle.split(' ')
         if (borderStyleList.length === 1) {
@@ -34,35 +57,51 @@ export const EditBorderStyle = () => {
 
     const updateBorderStyle = (_borderStyle: string, position: string) => {
         const borderStyleList = borderStyle.split(' ')
+        let newBorderStyle = ''
         if (borderStyleList.length === 1) {
             if (position === 'top') {
                 dispatch(setBorderStyle(`${_borderStyle} ${borderStyle} ${borderStyle} ${borderStyle}`))
+                newBorderStyle = `${_borderStyle} ${borderStyle} ${borderStyle} ${borderStyle}`
             } else if (position === 'right') {
                 dispatch(setBorderStyle(`${borderStyle} ${_borderStyle} ${borderStyle} ${borderStyle}`))
+                newBorderStyle = `${borderStyle} ${_borderStyle} ${borderStyle} ${borderStyle}`
             } else if (position === 'bottom') {
                 dispatch(setBorderStyle(`${borderStyle} ${borderStyle} ${_borderStyle} ${borderStyle}`))
+                newBorderStyle = `${borderStyle} ${borderStyle} ${_borderStyle} ${borderStyle}`
             } else if (position === 'left') {
                 dispatch(setBorderStyle(`${borderStyle} ${borderStyle} ${borderStyle} ${_borderStyle}`))
+                newBorderStyle = `${borderStyle} ${borderStyle} ${borderStyle} ${_borderStyle}`
             }
         } else {
             if (position === 'top') {
                 borderStyleList[0] = _borderStyle
-                const borderStyleStrings = borderStyleList.join(' ')
-                dispatch(setBorderStyle(borderStyleStrings))
             } else if (position === 'right') {
                 borderStyleList[1] = _borderStyle
-                const borderStyleStrings = borderStyleList.join(' ')
-                dispatch(setBorderStyle(borderStyleStrings))
             } else if (position === 'bottom') {
                 borderStyleList[2] = _borderStyle
-                const borderStyleStrings = borderStyleList.join(' ')
-                dispatch(setBorderStyle(borderStyleStrings))
             } else if (position === 'left') {
                 borderStyleList[3] = _borderStyle
-                const borderStyleStrings = borderStyleList.join(' ')
-                dispatch(setBorderStyle(borderStyleStrings))
             }
+            const borderStyleStrings = borderStyleList.join(' ')
+            dispatch(setBorderStyle(borderStyleStrings))
+            newBorderStyle = borderStyleList.join(' ')
         }
+        const newAllCssProps = { ...allCssProps, borderStyle: newBorderStyle }
+        dispatch(
+            saveCurrentCssProps({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                allCssProps: newAllCssProps,
+            })
+        )
+        dispatch(
+            saveCurrentCssCodes({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                cssProp: 'borderStyle',
+                cssValue: newBorderStyle,
+            })
+        )
     }
 
     return (
@@ -90,7 +129,7 @@ export const EditBorderStyle = () => {
                         <Flex flexDirection={'column'} width={'40rem'} alignItems={'flex-end'}>
                             <Flex flexDirection={'row'} justifyContent={'space-between'}>
                                 <Button
-                                    onClick={() => dispatch(setBorderStyle('none'))}
+                                    onClick={() => onClickBorderStyle('none')}
                                     fontSize={'1.2rem'}
                                     margin={'0.1rem'}
                                     height={'2rem'}
@@ -99,7 +138,7 @@ export const EditBorderStyle = () => {
                                     none
                                 </Button>
                                 <Button
-                                    onClick={() => dispatch(setBorderStyle('hidden'))}
+                                    onClick={() => onClickBorderStyle('hidden')}
                                     fontSize={'1.2rem'}
                                     margin={'0.1rem'}
                                     height={'2rem'}
@@ -108,7 +147,7 @@ export const EditBorderStyle = () => {
                                     hidden
                                 </Button>
                                 <Button
-                                    onClick={() => dispatch(setBorderStyle('dotted'))}
+                                    onClick={() => onClickBorderStyle('dotted')}
                                     fontSize={'1.2rem'}
                                     margin={'0.1rem'}
                                     height={'2rem'}
@@ -117,7 +156,7 @@ export const EditBorderStyle = () => {
                                     dotted
                                 </Button>
                                 <Button
-                                    onClick={() => dispatch(setBorderStyle('dashed'))}
+                                    onClick={() => onClickBorderStyle('dashed')}
                                     fontSize={'1.2rem'}
                                     margin={'0.1rem'}
                                     height={'2rem'}
@@ -126,7 +165,7 @@ export const EditBorderStyle = () => {
                                     dashed
                                 </Button>
                                 <Button
-                                    onClick={() => dispatch(setBorderStyle('solid'))}
+                                    onClick={() => onClickBorderStyle('solid')}
                                     fontSize={'1.2rem'}
                                     margin={'0.1rem'}
                                     height={'2rem'}
@@ -137,7 +176,7 @@ export const EditBorderStyle = () => {
                             </Flex>
                             <Flex flexDirection={'row'} justifyContent={'space-between'}>
                                 <Button
-                                    onClick={() => dispatch(setBorderStyle('double'))}
+                                    onClick={() => onClickBorderStyle('double')}
                                     fontSize={'1.2rem'}
                                     margin={'0.1rem'}
                                     height={'2rem'}
@@ -146,7 +185,7 @@ export const EditBorderStyle = () => {
                                     double
                                 </Button>
                                 <Button
-                                    onClick={() => dispatch(setBorderStyle('groove'))}
+                                    onClick={() => onClickBorderStyle('groove')}
                                     fontSize={'1.2rem'}
                                     margin={'0.1rem'}
                                     height={'2rem'}
@@ -155,7 +194,7 @@ export const EditBorderStyle = () => {
                                     groove
                                 </Button>
                                 <Button
-                                    onClick={() => dispatch(setBorderStyle('ridge'))}
+                                    onClick={() => onClickBorderStyle('ridge')}
                                     fontSize={'1.2rem'}
                                     margin={'0.1rem'}
                                     height={'2rem'}
@@ -164,7 +203,7 @@ export const EditBorderStyle = () => {
                                     ridge
                                 </Button>
                                 <Button
-                                    onClick={() => dispatch(setBorderStyle('inset'))}
+                                    onClick={() => onClickBorderStyle('inset')}
                                     fontSize={'1.2rem'}
                                     margin={'0.1rem'}
                                     height={'2rem'}
@@ -173,7 +212,7 @@ export const EditBorderStyle = () => {
                                     inset
                                 </Button>
                                 <Button
-                                    onClick={() => dispatch(setBorderStyle('outset'))}
+                                    onClick={() => onClickBorderStyle('outset')}
                                     fontSize={'1.2rem'}
                                     margin={'0.1rem'}
                                     height={'2rem'}

--- a/src/components/cssEditArea/borderWidth/EditBorderWidth.tsx
+++ b/src/components/cssEditArea/borderWidth/EditBorderWidth.tsx
@@ -12,7 +12,7 @@ import {
     Box,
 } from '@chakra-ui/react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setBorderWidth } from '../../buttonView/buttonViewSlice'
+import { getAllCssProps, setBorderWidth } from '../../buttonView/buttonViewSlice'
 import { AddIcon } from '@chakra-ui/icons'
 import { motion } from 'framer-motion'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
@@ -21,8 +21,12 @@ import { EditBorderWidthTop } from './borderWidthTop/EditBorderWidthTop'
 import { EditBorderWidthRight } from './borderWidthRight/EditBorderWidthRight'
 import { EditBorderWidthBottom } from './borderWidthBottom/EditBorderWidthBottom'
 import { EditBorderWidthLeft } from './borderWidthLeft/EditBorderWidthLeft'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderWidth = () => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
     const displayBorderWidth = useAppSelector((state) => state.cssCustomArea.displayBorderWidth)
@@ -31,8 +35,25 @@ export const EditBorderWidth = () => {
     const [allBorderWidth, setAllBorderWidth] = useState('')
 
     const onChangeValue = (v: number) => {
+        // TODO:親のborderWidthだけ他疑似要素に変更時見た目を保持していない（データは保持できている）
         setAllBorderWidth(v.toString() + 'px')
         dispatch(setBorderWidth(v.toString() + 'px'))
+        const newAllCssProps = { ...allCssProps, borderWidth: v.toString() + 'px' }
+        dispatch(
+            saveCurrentCssProps({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                allCssProps: newAllCssProps,
+            })
+        )
+        dispatch(
+            saveCurrentCssCodes({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                cssProp: 'borderWidth',
+                cssValue: v.toString() + 'px',
+            })
+        )
     }
     return (
         <>

--- a/src/components/cssEditArea/borderWidth/borderWidthBottom/EditBorderWidthBottom.tsx
+++ b/src/components/cssEditArea/borderWidth/borderWidthBottom/EditBorderWidthBottom.tsx
@@ -1,9 +1,13 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderWidth } from '../../../buttonView/buttonViewSlice'
+import { getAllCssProps, setBorderWidth } from '../../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderWidthBottom = memo(() => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
     const [showTooltipBorderWidthBottom, setShowTooltipBorderWidthBottom] = useState(false)
@@ -20,6 +24,22 @@ export const EditBorderWidthBottom = memo(() => {
         if (borderWidthList.length === 4) {
             borderWidthList[2] = v.toString() + 'px'
             dispatch(setBorderWidth(borderWidthList.join(' ')))
+            const newAllCssProps = { ...allCssProps, borderWidth: borderWidthList.join(' ') }
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    allCssProps: newAllCssProps,
+                })
+            )
+            dispatch(
+                saveCurrentCssCodes({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssProp: 'borderWidth',
+                    cssValue: borderWidthList.join(' '),
+                })
+            )
         } else {
             dispatch(setBorderWidth(`${borderWidth} ${borderWidth} ${borderWidth} ${borderWidth}`))
         }

--- a/src/components/cssEditArea/borderWidth/borderWidthLeft/EditBorderWidthLeft.tsx
+++ b/src/components/cssEditArea/borderWidth/borderWidthLeft/EditBorderWidthLeft.tsx
@@ -1,9 +1,13 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderWidth } from '../../../buttonView/buttonViewSlice'
+import { getAllCssProps, setBorderWidth } from '../../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderWidthLeft = memo(() => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
     const [showTooltipBorderWidthLeft, setShowTooltipBorderWidthLeft] = useState(false)
@@ -20,6 +24,22 @@ export const EditBorderWidthLeft = memo(() => {
         if (borderWidthList.length === 4) {
             borderWidthList[3] = v.toString() + 'px'
             dispatch(setBorderWidth(borderWidthList.join(' ')))
+            const newAllCssProps = { ...allCssProps, borderWidth: borderWidthList.join(' ') }
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    allCssProps: newAllCssProps,
+                })
+            )
+            dispatch(
+                saveCurrentCssCodes({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssProp: 'borderWidth',
+                    cssValue: borderWidthList.join(' '),
+                })
+            )
         } else {
             dispatch(setBorderWidth(`${borderWidth} ${borderWidth} ${borderWidth} ${borderWidth}`))
         }

--- a/src/components/cssEditArea/borderWidth/borderWidthRight/EditBorderWidthRight.tsx
+++ b/src/components/cssEditArea/borderWidth/borderWidthRight/EditBorderWidthRight.tsx
@@ -1,9 +1,13 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderWidth } from '../../../buttonView/buttonViewSlice'
+import { getAllCssProps, setBorderWidth } from '../../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderWidthRight = memo(() => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
     const [showTooltipBorderWidthRight, setShowTooltipBorderWidthRight] = useState(false)
@@ -20,6 +24,22 @@ export const EditBorderWidthRight = memo(() => {
         if (borderWidthList.length === 4) {
             borderWidthList[1] = v.toString() + 'px'
             dispatch(setBorderWidth(borderWidthList.join(' ')))
+            const newAllCssProps = { ...allCssProps, borderWidth: borderWidthList.join(' ') }
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    allCssProps: newAllCssProps,
+                })
+            )
+            dispatch(
+                saveCurrentCssCodes({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssProp: 'borderWidth',
+                    cssValue: borderWidthList.join(' '),
+                })
+            )
         } else {
             dispatch(setBorderWidth(`${borderWidth} ${borderWidth} ${borderWidth} ${borderWidth}`))
         }

--- a/src/components/cssEditArea/borderWidth/borderWidthTop/EditBorderWidthTop.tsx
+++ b/src/components/cssEditArea/borderWidth/borderWidthTop/EditBorderWidthTop.tsx
@@ -1,9 +1,13 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderWidth } from '../../../buttonView/buttonViewSlice'
+import { getAllCssProps, setBorderWidth } from '../../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderWidthTop = memo(() => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
     const [showTooltipBorderWidthTop, setShowTooltipBorderWidthTop] = useState(false)
@@ -20,6 +24,22 @@ export const EditBorderWidthTop = memo(() => {
         if (borderWidthList.length === 4) {
             borderWidthList[0] = v.toString() + 'px'
             dispatch(setBorderWidth(borderWidthList.join(' ')))
+            const newAllCssProps = { ...allCssProps, borderWidth: borderWidthList.join(' ') }
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    allCssProps: newAllCssProps,
+                })
+            )
+            dispatch(
+                saveCurrentCssCodes({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssProp: 'borderWidth',
+                    cssValue: borderWidthList.join(' '),
+                })
+            )
         } else {
             dispatch(setBorderWidth(`${borderWidth} ${borderWidth} ${borderWidth} ${borderWidth}`))
         }

--- a/src/components/cssEditArea/color/EditColor.tsx
+++ b/src/components/cssEditArea/color/EditColor.tsx
@@ -4,11 +4,15 @@ import { motion } from 'framer-motion'
 import React, { useState } from 'react'
 import { AlphaPicker, ChromePicker, ColorResult, HuePicker } from 'react-color'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setColor } from '../../buttonView/buttonViewSlice'
+import { getAllCssProps, setColor } from '../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
 import { rotateElementVariants } from '../animation/rotateElement'
 
 export const EditColor = () => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const colorRgb = useAppSelector((state) => state.buttonView.color)
     const displayColor = useAppSelector((state) => state.cssCustomArea.displayColor)
@@ -16,6 +20,22 @@ export const EditColor = () => {
     const handleChange = (color: ColorResult) => {
         const rgba = `rgba(${color.rgb.r},${color.rgb.g},${color.rgb.b},${color.rgb.a})`
         dispatch(setColor(rgba))
+        const newAllCssProps = { ...allCssProps, color: rgba }
+        dispatch(
+            saveCurrentCssProps({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                allCssProps: newAllCssProps,
+            })
+        )
+        dispatch(
+            saveCurrentCssCodes({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                cssProp: 'color',
+                cssValue: rgba,
+            })
+        )
     }
     return (
         <>

--- a/src/components/cssEditArea/fontSize/FontSize.tsx
+++ b/src/components/cssEditArea/fontSize/FontSize.tsx
@@ -1,15 +1,35 @@
 import React, { useState } from 'react'
 import { Slider, SliderTrack, SliderFilledTrack, SliderThumb, SliderMark, Tooltip, Flex, Text } from '@chakra-ui/react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setFontSize } from '../../buttonView/buttonViewSlice'
+import { getAllCssProps, setFontSize } from '../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 
 export const FontSize = () => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const fontSize = useAppSelector((state) => state.buttonView.fontSize)
     const [showTooltip, setShowTooltip] = useState(false)
     const displayFontSize = useAppSelector((state) => state.cssCustomArea.displayFontSize)
     const onChangeValue = (v: number) => {
         dispatch(setFontSize(v.toString() + 'px'))
+        const newAllCssProps = { ...allCssProps, fontSize: v.toString() + 'px' }
+        dispatch(
+            saveCurrentCssProps({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                allCssProps: newAllCssProps,
+            })
+        )
+        dispatch(
+            saveCurrentCssCodes({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                cssProp: 'fontSize',
+                cssValue: v.toString() + 'px',
+            })
+        )
     }
     return (
         <>

--- a/src/components/cssEditArea/height/EditHeight.tsx
+++ b/src/components/cssEditArea/height/EditHeight.tsx
@@ -1,15 +1,35 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setHeight } from '../../buttonView/buttonViewSlice'
+import { getAllCssProps, setHeight } from '../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 
 export const EditHeight = () => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const [showTooltip, setShowTooltip] = useState(false)
     const dispatch = useAppDispatch()
     const height = useAppSelector((state) => state.buttonView.height)
     const displayHeight = useAppSelector((state) => state.cssCustomArea.displayHeight)
     const onChangeValue = (v: number) => {
         dispatch(setHeight(v.toString() + 'px'))
+        const newAllCssProps = { ...allCssProps, height: v.toString() + 'px' }
+        dispatch(
+            saveCurrentCssProps({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                allCssProps: newAllCssProps,
+            })
+        )
+        dispatch(
+            saveCurrentCssCodes({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                cssProp: 'height',
+                cssValue: v.toString() + 'px',
+            })
+        )
     }
 
     return (

--- a/src/components/cssEditArea/padding/Padding.tsx
+++ b/src/components/cssEditArea/padding/Padding.tsx
@@ -12,7 +12,7 @@ import {
     Box,
 } from '@chakra-ui/react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setPadding } from '../../buttonView/buttonViewSlice'
+import { getAllCssProps, setPadding } from '../../buttonView/buttonViewSlice'
 import { AddIcon } from '@chakra-ui/icons'
 import { motion } from 'framer-motion'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
@@ -21,8 +21,12 @@ import { EditPaddingTop } from './paddingTop/EditPaddingTop'
 import { EditPaddingRight } from './paddingRight/EditPaddingRight'
 import { EditPaddingBottom } from './paddingBottom/EditPaddingBottom'
 import { EditPaddingLeft } from './paddingLeft/EditPaddingLeft'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 
 export const Padding = () => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const padding = useAppSelector((state) => state.buttonView.padding)
     const displayPadding = useAppSelector((state) => state.cssCustomArea.displayPadding)
@@ -31,8 +35,25 @@ export const Padding = () => {
     const [allPadding, setAllPadding] = useState('')
 
     const onChangeValue = (v: number) => {
+        // TODO:親のpaddingだけ他疑似要素に変更時見た目を保持していない（データは保持できている）
         setAllPadding(v.toString() + 'px')
         dispatch(setPadding(v.toString() + 'px'))
+        const newAllCssProps = { ...allCssProps, padding: v.toString() + 'px' }
+        dispatch(
+            saveCurrentCssProps({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                allCssProps: newAllCssProps,
+            })
+        )
+        dispatch(
+            saveCurrentCssCodes({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                cssProp: 'padding',
+                cssValue: v.toString() + 'px',
+            })
+        )
     }
     return (
         <>

--- a/src/components/cssEditArea/padding/paddingBottom/EditPaddingBottom.tsx
+++ b/src/components/cssEditArea/padding/paddingBottom/EditPaddingBottom.tsx
@@ -1,9 +1,13 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setPadding } from '../../../buttonView/buttonViewSlice'
+import { getAllCssProps, setPadding } from '../../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditPaddingBottom = memo(() => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const padding = useAppSelector((state) => state.buttonView.padding)
     const [showTooltipPaddingBottom, setShowTooltipPaddingBottom] = useState(false)
@@ -20,6 +24,22 @@ export const EditPaddingBottom = memo(() => {
         if (paddingList.length === 4) {
             paddingList[2] = v.toString() + 'px'
             dispatch(setPadding(paddingList.join(' ')))
+            const newAllCssProps = { ...allCssProps, padding: paddingList.join(' ') }
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    allCssProps: newAllCssProps,
+                })
+            )
+            dispatch(
+                saveCurrentCssCodes({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssProp: 'padding',
+                    cssValue: paddingList.join(' '),
+                })
+            )
         } else {
             dispatch(setPadding(`${padding} ${padding} ${padding} ${padding}`))
         }

--- a/src/components/cssEditArea/padding/paddingLeft/EditPaddingLeft.tsx
+++ b/src/components/cssEditArea/padding/paddingLeft/EditPaddingLeft.tsx
@@ -1,9 +1,13 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setPadding } from '../../../buttonView/buttonViewSlice'
+import { getAllCssProps, setPadding } from '../../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditPaddingLeft = memo(() => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const padding = useAppSelector((state) => state.buttonView.padding)
     const [showTooltipPaddingLeft, setShowTooltipPaddingLeft] = useState(false)
@@ -20,6 +24,22 @@ export const EditPaddingLeft = memo(() => {
         if (paddingList.length === 4) {
             paddingList[3] = v.toString() + 'px'
             dispatch(setPadding(paddingList.join(' ')))
+            const newAllCssProps = { ...allCssProps, padding: paddingList.join(' ') }
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    allCssProps: newAllCssProps,
+                })
+            )
+            dispatch(
+                saveCurrentCssCodes({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssProp: 'padding',
+                    cssValue: paddingList.join(' '),
+                })
+            )
         } else {
             dispatch(setPadding(`${padding} ${padding} ${padding} ${padding}`))
         }

--- a/src/components/cssEditArea/padding/paddingRight/EditPaddingRight.tsx
+++ b/src/components/cssEditArea/padding/paddingRight/EditPaddingRight.tsx
@@ -1,9 +1,13 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setPadding } from '../../../buttonView/buttonViewSlice'
+import { getAllCssProps, setPadding } from '../../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditPaddingRight = memo(() => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const padding = useAppSelector((state) => state.buttonView.padding)
     const [showTooltipPaddingRight, setShowTooltipPaddingRight] = useState(false)
@@ -20,6 +24,22 @@ export const EditPaddingRight = memo(() => {
         if (paddingList.length === 4) {
             paddingList[1] = v.toString() + 'px'
             dispatch(setPadding(paddingList.join(' ')))
+            const newAllCssProps = { ...allCssProps, padding: paddingList.join(' ') }
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    allCssProps: newAllCssProps,
+                })
+            )
+            dispatch(
+                saveCurrentCssCodes({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssProp: 'padding',
+                    cssValue: paddingList.join(' '),
+                })
+            )
         } else {
             dispatch(setPadding(`${padding} ${padding} ${padding} ${padding}`))
         }

--- a/src/components/cssEditArea/padding/paddingTop/EditPaddingTop.tsx
+++ b/src/components/cssEditArea/padding/paddingTop/EditPaddingTop.tsx
@@ -1,9 +1,13 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setPadding } from '../../../buttonView/buttonViewSlice'
+import { getAllCssProps, setPadding } from '../../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditPaddingTop = memo(() => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const dispatch = useAppDispatch()
     const padding = useAppSelector((state) => state.buttonView.padding)
     const [showTooltipPaddingTop, setShowTooltipPaddingTop] = useState(false)
@@ -20,6 +24,22 @@ export const EditPaddingTop = memo(() => {
         if (paddingList.length === 4) {
             paddingList[0] = v.toString() + 'px'
             dispatch(setPadding(paddingList.join(' ')))
+            const newAllCssProps = { ...allCssProps, padding: paddingList.join(' ') }
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    allCssProps: newAllCssProps,
+                })
+            )
+            dispatch(
+                saveCurrentCssCodes({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssProp: 'padding',
+                    cssValue: paddingList.join(' '),
+                })
+            )
         } else {
             dispatch(setPadding(`${padding} ${padding} ${padding} ${padding}`))
         }

--- a/src/components/cssEditArea/width/EditWidth.tsx
+++ b/src/components/cssEditArea/width/EditWidth.tsx
@@ -1,15 +1,37 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setWidth } from '../../buttonView/buttonViewSlice'
+import { getAllCssProps, setWidth } from '../../buttonView/buttonViewSlice'
+import { saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 
 export const EditWidth = () => {
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const allCssProps = useAppSelector((state) => getAllCssProps(state))
     const [showTooltip, setShowTooltip] = useState(false)
     const dispatch = useAppDispatch()
     const width = useAppSelector((state) => state.buttonView.width)
     const displayWidth = useAppSelector((state) => state.cssCustomArea.displayWidth)
+
     const onChangeValue = (v: number) => {
         dispatch(setWidth(v.toString() + 'px'))
+        // saveCurrentCssPropsにて現在の↑↑で更新された現在のCSSプロパティを入れると非同期処理の問題でスライドバーがガタつく為、新たに作成して代入している。
+        const newAllCssProps = { ...allCssProps, width: v.toString() + 'px' }
+        dispatch(
+            saveCurrentCssProps({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                allCssProps: newAllCssProps,
+            })
+        )
+        dispatch(
+            saveCurrentCssCodes({
+                elementName: selectedElementName,
+                classNames: selectedElementClass,
+                cssProp: 'width',
+                cssValue: v.toString() + 'px',
+            })
+        )
     }
 
     return (

--- a/src/components/pseudoArea/pseudoAreaSlice.ts
+++ b/src/components/pseudoArea/pseudoAreaSlice.ts
@@ -4,15 +4,18 @@ import { cssTypes } from '../../types/cssTypes'
 import { buttonInitialState } from '../buttonView/buttonViewSlice'
 import { cssCustomAreaDisplay, cssCustomAreaType } from '../cssCustomArea/cssCustomAreaSlice'
 
+type arrayType = {
+    [prop: string]: statesType
+}
+
 type statesType = {
     elementName: string
     classNames: string[]
     cssProps: cssTypes
     customAreaDisplay: cssCustomAreaType
-}
-
-type arrayType = {
-    [prop: string]: statesType
+    cssCodes: {
+        [prop: string]: string
+    }
 }
 
 const initCustomAreaDisplay = { ...cssCustomAreaDisplay }
@@ -22,6 +25,7 @@ const initCssState: statesType = {
     classNames: [], // hover, focus, active, etc...(CSSの仕組み上、複合する可能性あり['hover', 'focus']みたいな感じ)
     cssProps: initCssProps,
     customAreaDisplay: initCustomAreaDisplay,
+    cssCodes: {}, // {width: '100px', height: '100px' ...}
 }
 
 const initCssStates: arrayType = {
@@ -180,6 +184,55 @@ export const pseudoAreaSlice = createSlice({
             }
             state.cssStates[uid] = newCssState
         },
+        saveCurrentCssCodes: (
+            state,
+            action: PayloadAction<{
+                elementName: string
+                classNames: string[]
+                cssProp: string
+                cssValue: string
+            }>
+        ) => {
+            const elementName = action.payload.elementName
+            const classNames = action.payload.classNames
+            const cssProp = action.payload.cssProp
+            const cssValue = action.payload.cssValue
+
+            const uid = getElementUid(elementName, classNames)
+            const cssState = current(state.cssStates)[uid]
+            const newCssState = {
+                ...cssState,
+                cssCodes: {
+                    ...cssState.cssCodes,
+                    [cssProp]: cssValue,
+                },
+            }
+            state.cssStates[uid] = newCssState
+        },
+        removeCurrentCssCodes: (
+            state,
+            action: PayloadAction<{
+                elementName: string
+                classNames: string[]
+                cssProp: string
+            }>
+        ) => {
+            const elementName = action.payload.elementName
+            const classNames = action.payload.classNames
+            const cssProp = action.payload.cssProp
+
+            const uid = getElementUid(elementName, classNames)
+            const cssState = current(state.cssStates)[uid]
+            const newCssCodes = {
+                ...cssState.cssCodes,
+            }
+            delete newCssCodes[cssProp]
+            const newCssState = {
+                ...cssState,
+                cssCodes: newCssCodes,
+            }
+            state.cssStates[uid] = newCssState
+        },
         setPseudoButtonLIfeCycle: (
             state,
             action: PayloadAction<{
@@ -255,6 +308,8 @@ export const {
     createNewCssStates,
     saveCurrentCustomAreaDisplay,
     saveCurrentCssProps,
+    saveCurrentCssCodes,
+    removeCurrentCssCodes,
     setPseudoButtonLIfeCycle,
     setIsActiveMain,
     setIsActiveBefore,

--- a/src/page/Editor/Editor.tsx
+++ b/src/page/Editor/Editor.tsx
@@ -23,13 +23,7 @@ const Editor = () => {
             <GridItem area={'pseudo'} backgroundColor={'rgb(26 32 44)'} overflowX={'hidden'} overflowY={'scroll'}>
                 <PseudoArea />
             </GridItem>
-            <GridItem
-                display={'flex'}
-                flexDirection={'column'}
-                area={'custom'}
-                backgroundColor={'rgb(26 32 44)'}
-                height={'30rem'}
-            >
+            <GridItem display={'flex'} flexDirection={'column'} area={'custom'} backgroundColor={'rgb(26 32 44)'}>
                 <CssCustomArea />
             </GridItem>
             <GridItem area={'edit'} backgroundColor={'gray.500'} overflowX={'hidden'} overflowY={'scroll'}>


### PR DESCRIPTION
一度選択された疑似要素は中身がからでも表示されているが、これは実際の動作では問題がないのと、別issueで書き出したいので放置