### PR TITLE
疑似クラスが変更されたときにボタンにも適応されるようにした

### DIFF
--- a/src/components/buttonView/ButtonView.tsx
+++ b/src/components/buttonView/ButtonView.tsx
@@ -1,40 +1,32 @@
 import { Flex } from '@chakra-ui/react'
+import { css, CSSObject } from '@emotion/react'
 import React from 'react'
 import { useAppSelector } from '../../hooks'
 
 export const ButtonView = () => {
-    const color = useAppSelector((state) => state.buttonView.color)
-    const backgroundColor = useAppSelector((state) => state.buttonView.backgroundColor)
-    const border = useAppSelector((state) => state.buttonView.border)
-    const padding = useAppSelector((state) => state.buttonView.padding)
-    const textDecoration = useAppSelector((state) => state.buttonView.textDecoration)
-    const display = useAppSelector((state) => state.buttonView.display)
-    const fontSize = useAppSelector((state) => state.buttonView.fontSize)
-    const borderColor = useAppSelector((state) => state.buttonView.borderColor)
-    const borderStyle = useAppSelector((state) => state.buttonView.borderStyle)
-    const borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
-    const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
-    const width = useAppSelector((state) => state.buttonView.width)
-    const height = useAppSelector((state) => state.buttonView.height)
-    const buttonStyle = {
-        color: color,
-        backgroundColor: backgroundColor,
-        border: border,
-        padding: padding,
-        textDecoration: textDecoration,
-        display: display,
-        fontSize: fontSize,
-        borderColor: borderColor,
-        borderStyle: borderStyle,
-        borderWidth: borderWidth,
-        borderRadius: borderRadius,
-        width: width,
-        height: height,
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let buttonStyle = {} as CSSObject
+    for (const value of Object.values(cssStates)) {
+        if (value.elementName === 'Main' && value.classNames.length === 0) {
+            buttonStyle = { ...buttonStyle, ...value.cssProps }
+        } else {
+            const _elementName = value.elementName === 'Main' ? '' : '::' + value.elementName
+            const _elementClass = value.classNames.length === 0 ? '' : ':' + value.classNames.join(':')
+            const resultStr = '&' + _elementName + _elementClass
+            const _buttonStyle = {
+                [resultStr]: { ...value.cssProps },
+            }
+            buttonStyle = { ...buttonStyle, ..._buttonStyle }
+        }
     }
+    const buttonStyles = {
+        ...buttonStyle,
+    } as CSSObject
+    const cssProps = css(buttonStyles)
 
     return (
         <Flex height={'100%'} alignItems={'center'} justifyContent={'center'}>
-            <button style={buttonStyle}>Text</button>
+            <button css={cssProps}>Text</button>
         </Flex>
     )
 }

--- a/src/components/pseudoArea/PseudoArea.tsx
+++ b/src/components/pseudoArea/PseudoArea.tsx
@@ -30,24 +30,24 @@ export const PseudoArea = () => {
             </Text>
             <PseudoButton
                 type="pseudoElements"
-                TitleText={'Before'}
+                TitleText={'before'}
                 isActive={isActiveBefore}
                 setter={setIsActiveBefore}
             />
             <PseudoButton
                 type="pseudoElements"
-                TitleText={'After'}
+                TitleText={'after'}
                 isActive={isActiveAfter}
                 setter={setIsActiveAfter}
             />
             <Text textAlign={'center'} fontSize={'1.5rem'}>
                 Pseudo Class
             </Text>
-            <PseudoButton type="pseudoClass" TitleText={'Hover'} isActive={isActiveHover} setter={setIsActiveHover} />
-            <PseudoButton type="pseudoClass" TitleText={'Focus'} isActive={isActiveFocus} setter={setIsActiveFocus} />
+            <PseudoButton type="pseudoClass" TitleText={'hover'} isActive={isActiveHover} setter={setIsActiveHover} />
+            <PseudoButton type="pseudoClass" TitleText={'focus'} isActive={isActiveFocus} setter={setIsActiveFocus} />
             <PseudoButton
                 type="pseudoClass"
-                TitleText={'Active'}
+                TitleText={'active'}
                 isActive={isActiveActive}
                 setter={setIsActiveActive}
             />


### PR DESCRIPTION
疑似クラスのみ適用できてます。

疑似エレメントはCSS要素の問題で未適用

さらに、button viewがCSSを読みだすストアを変更している関係でテンプレートが機能していません。