### PR TITLE
Feat/fix remove buttonviewslice

### DIFF
--- a/src/components/buttonView/buttonViewSlice.ts
+++ b/src/components/buttonView/buttonViewSlice.ts
@@ -18,6 +18,8 @@ export const buttonInitialState: cssTypes = {
     height: '75x',
 }
 
+// TODO:引っ越しが完了したので現状不要になってはいるが、template button で利用していて、消すと非対応プロパティがわからなくなるので、いったん残しておきます
+// template button 側が対応したら削除します
 export const buttonViewSlice = createSlice({
     name: 'buttonView',
     initialState: buttonInitialState,

--- a/src/components/codeArea/cssRenderingArea/CssRenderingArea.tsx
+++ b/src/components/codeArea/cssRenderingArea/CssRenderingArea.tsx
@@ -21,10 +21,12 @@ export const CssRenderingArea = () => {
 
         buildContent = (elementName: string, elementClass: string[]) => {
             const uid = getElementUid(elementName, elementClass)
-            const codes = cssStates[uid].cssCodes
+            const _cssStates = cssStates[uid]
             const resultStr = []
-            for (const [key, value] of Object.entries(codes)) {
-                resultStr.push(transformCssLowerCase(key) + ': ' + value)
+            for (const [key, value] of Object.entries(_cssStates.cssProps)) {
+                if (_cssStates.customAreaDisplay[key]) {
+                    resultStr.push(transformCssLowerCase(key) + ': ' + value)
+                }
             }
             return resultStr.map((str) => {
                 return <Text key={str}>&emsp;{str}</Text>

--- a/src/components/codeArea/defaultButtonCss.ts
+++ b/src/components/codeArea/defaultButtonCss.ts
@@ -1,6 +1,6 @@
-import { cssTypes } from '../../types/cssTypes'
+import { arrayType } from '../../types/cssTypes'
 
-export const defaultButtonCss: cssTypes = {
+export const defaultButtonCss: arrayType = {
     color: 'rgba(255,0,0,1)',
     backgroundColor: 'rgba(0,0,255,1)',
     border: 'none',

--- a/src/components/copyButton/CopyButton.tsx
+++ b/src/components/copyButton/CopyButton.tsx
@@ -8,6 +8,7 @@ import { copyAnimeVariants } from './animation/copyAnimation'
 
 export const CopyButton = () => {
     // TODO:codeArea, copyButton, buttonViewでデータはしているが、中身が同期しているかは不明。整合性の確認が必要
+    // TODO:buttonviewSlice -> pseudoSliceにお引越しの関係上、このコピーボタンは一時的に召されています
     const width = useAppSelector((state) => state.buttonView.width)
     const isDisplayWidth = defaultButtonCss.width === 'ALWAYS' || defaultButtonCss.width !== width
     const height = useAppSelector((state) => state.buttonView.height)

--- a/src/components/cssCustomArea/CustomAreaButton.tsx
+++ b/src/components/cssCustomArea/CustomAreaButton.tsx
@@ -1,10 +1,9 @@
-import React, { memo, useEffect, useRef } from 'react'
+import React, { memo } from 'react'
 import { Button, Flex, Text } from '@chakra-ui/react'
 import { ChatIcon } from '@chakra-ui/icons'
 import { useAppDispatch, useAppSelector } from '../../hooks'
 import { customButtonStyle } from './initStyle'
-import { removeCurrentCssCodes, saveCurrentCssCodes, saveCustomAreaDisplay } from '../pseudoArea/pseudoAreaSlice'
-import { getAllCssProps } from '../buttonView/buttonViewSlice'
+import { saveCustomAreaDisplay } from '../pseudoArea/pseudoAreaSlice'
 
 type propsType = {
     text: string
@@ -12,11 +11,9 @@ type propsType = {
 }
 
 export const CustomAreaButton = memo(({ text, isDisplay }: propsType) => {
-    const isFirstRender = useRef(true)
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent)
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent)
     const dispatch = useAppDispatch()
-    const currentAllCssProps = useAppSelector((state) => getAllCssProps(state))
     const updateCustomAreaDisplay = (value: boolean) => {
         dispatch(
             saveCustomAreaDisplay({
@@ -27,36 +24,6 @@ export const CustomAreaButton = memo(({ text, isDisplay }: propsType) => {
             })
         )
     }
-    useEffect(() => {
-        if (isFirstRender.current) {
-            isFirstRender.current = false
-            return
-        }
-        let cssVal = ''
-        for (const [key, value] of Object.entries(currentAllCssProps)) {
-            if (key === text) {
-                cssVal = value
-            }
-        }
-        if (isDisplay) {
-            dispatch(
-                saveCurrentCssCodes({
-                    elementName: selectedElementName,
-                    classNames: selectedElementClass,
-                    cssProp: text,
-                    cssValue: cssVal,
-                })
-            )
-        } else {
-            dispatch(
-                removeCurrentCssCodes({
-                    elementName: selectedElementName,
-                    classNames: selectedElementClass,
-                    cssProp: text,
-                })
-            )
-        }
-    }, [isDisplay])
     return (
         <Flex flexDirection={'column'} justifyContent={'space-around'} width={customButtonStyle.width}>
             <Button

--- a/src/components/cssEditArea/backgroundColor/EditBackgroundColor.tsx
+++ b/src/components/cssEditArea/backgroundColor/EditBackgroundColor.tsx
@@ -4,18 +4,17 @@ import { motion } from 'framer-motion'
 import React, { useState } from 'react'
 import { AlphaPicker, ChromePicker, ColorResult, HuePicker } from 'react-color'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setBackgroundColor } from '../../buttonView/buttonViewSlice'
 import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
 import { rotateElementVariants } from '../animation/rotateElement'
 
 export const EditBackgroundColor = () => {
-    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
-    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent)
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent)
     const dispatch = useAppDispatch()
     const uid = getElementUid(selectedElementName, selectedElementClass)
-    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
-    let backgroundColor = useAppSelector((state) => state.buttonView.backgroundColor)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let backgroundColor = cssStates[uid].cssProps.backgroundColor
     if (!backgroundColor) {
         backgroundColor = ''
     }
@@ -23,7 +22,6 @@ export const EditBackgroundColor = () => {
     const [isDisplayDetail, setIsDisplayDetail] = useState(false)
     const handleChange = (color: ColorResult) => {
         const rgba = `rgba(${color.rgb.r},${color.rgb.g},${color.rgb.b},${color.rgb.a})`
-        dispatch(setBackgroundColor(rgba))
         dispatch(
             saveCurrentCssProps({
                 elementName: selectedElementName,

--- a/src/components/cssEditArea/backgroundColor/EditBackgroundColor.tsx
+++ b/src/components/cssEditArea/backgroundColor/EditBackgroundColor.tsx
@@ -5,7 +5,7 @@ import React, { useState } from 'react'
 import { AlphaPicker, ChromePicker, ColorResult, HuePicker } from 'react-color'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
 import { setBackgroundColor } from '../../buttonView/buttonViewSlice'
-import { getElementUid, saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
 import { rotateElementVariants } from '../animation/rotateElement'
 
@@ -13,9 +13,12 @@ export const EditBackgroundColor = () => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const backgroundColor = useAppSelector((state) => state.buttonView.backgroundColor)
     const uid = getElementUid(selectedElementName, selectedElementClass)
     const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
+    let backgroundColor = useAppSelector((state) => state.buttonView.backgroundColor)
+    if (!backgroundColor) {
+        backgroundColor = ''
+    }
     const displayBackgroundColor = cssStates[uid].customAreaDisplay.backgroundColor
     const [isDisplayDetail, setIsDisplayDetail] = useState(false)
     const handleChange = (color: ColorResult) => {
@@ -27,14 +30,6 @@ export const EditBackgroundColor = () => {
                 classNames: selectedElementClass,
                 cssPropKey: 'backgroundColor',
                 cssPropValue: rgba,
-            })
-        )
-        dispatch(
-            saveCurrentCssCodes({
-                elementName: selectedElementName,
-                classNames: selectedElementClass,
-                cssProp: 'backgroundColor',
-                cssValue: rgba,
             })
         )
     }

--- a/src/components/cssEditArea/borderColor/EditBorderColor.tsx
+++ b/src/components/cssEditArea/borderColor/EditBorderColor.tsx
@@ -4,7 +4,6 @@ import { motion } from 'framer-motion'
 import React, { useState } from 'react'
 import { AlphaPicker, ChromePicker, ColorResult, HuePicker } from 'react-color'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setBorderColor } from '../../buttonView/buttonViewSlice'
 import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
 import { rotateElementVariants } from '../animation/rotateElement'
@@ -15,7 +14,7 @@ export const EditBorderColor = () => {
     const dispatch = useAppDispatch()
     const uid = getElementUid(selectedElementName, selectedElementClass)
     const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
-    let borderColor = useAppSelector((state) => state.buttonView.borderColor)
+    let borderColor = cssStates[uid].cssProps.borderColor
     if (!borderColor) {
         borderColor = ''
     }
@@ -23,7 +22,6 @@ export const EditBorderColor = () => {
     const [isDisplayDetail, setIsDisplayDetail] = useState(false)
     const handleChange = (color: ColorResult) => {
         const rgba = `rgba(${color.rgb.r},${color.rgb.g},${color.rgb.b},${color.rgb.a})`
-        dispatch(setBorderColor(rgba))
         dispatch(
             saveCurrentCssProps({
                 elementName: selectedElementName,

--- a/src/components/cssEditArea/borderColor/EditBorderColor.tsx
+++ b/src/components/cssEditArea/borderColor/EditBorderColor.tsx
@@ -5,7 +5,7 @@ import React, { useState } from 'react'
 import { AlphaPicker, ChromePicker, ColorResult, HuePicker } from 'react-color'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
 import { setBorderColor } from '../../buttonView/buttonViewSlice'
-import { getElementUid, saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
 import { rotateElementVariants } from '../animation/rotateElement'
 
@@ -13,9 +13,12 @@ export const EditBorderColor = () => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const borderColor = useAppSelector((state) => state.buttonView.borderColor)
     const uid = getElementUid(selectedElementName, selectedElementClass)
     const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
+    let borderColor = useAppSelector((state) => state.buttonView.borderColor)
+    if (!borderColor) {
+        borderColor = ''
+    }
     const displayBorderColor = cssStates[uid].customAreaDisplay.borderColor
     const [isDisplayDetail, setIsDisplayDetail] = useState(false)
     const handleChange = (color: ColorResult) => {
@@ -27,14 +30,6 @@ export const EditBorderColor = () => {
                 classNames: selectedElementClass,
                 cssPropKey: 'borderColor',
                 cssPropValue: rgba,
-            })
-        )
-        dispatch(
-            saveCurrentCssCodes({
-                elementName: selectedElementName,
-                classNames: selectedElementClass,
-                cssProp: 'borderColor',
-                cssValue: rgba,
             })
         )
     }

--- a/src/components/cssEditArea/borderRadius/EditBorderRadius.tsx
+++ b/src/components/cssEditArea/borderRadius/EditBorderRadius.tsx
@@ -15,7 +15,7 @@ import { motion } from 'framer-motion'
 import React, { useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
 import { setBorderRadius } from '../../buttonView/buttonViewSlice'
-import { getElementUid, saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
 import { rotateElementVariants } from '../animation/rotateElement'
 import { EditBorderRadiusBottomLeftHorizontal } from './bottomLeft/EditBorderRadiusBottomLeftHorizontal'
@@ -32,7 +32,10 @@ export const EditBorderRadius = () => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    let borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    if (!borderRadius) {
+        borderRadius = ''
+    }
     const uid = getElementUid(selectedElementName, selectedElementClass)
     const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
     const displayBorderRadius = cssStates[uid].customAreaDisplay.borderRadius
@@ -50,14 +53,6 @@ export const EditBorderRadius = () => {
                 classNames: selectedElementClass,
                 cssPropKey: 'borderRadius',
                 cssPropValue: v.toString() + 'px',
-            })
-        )
-        dispatch(
-            saveCurrentCssCodes({
-                elementName: selectedElementName,
-                classNames: selectedElementClass,
-                cssProp: 'borderRadius',
-                cssValue: v.toString() + 'px',
             })
         )
     }

--- a/src/components/cssEditArea/borderRadius/EditBorderRadius.tsx
+++ b/src/components/cssEditArea/borderRadius/EditBorderRadius.tsx
@@ -14,7 +14,6 @@ import {
 import { motion } from 'framer-motion'
 import React, { useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setBorderRadius } from '../../buttonView/buttonViewSlice'
 import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
 import { rotateElementVariants } from '../animation/rotateElement'
@@ -29,15 +28,15 @@ import { EditBorderRadiusTopRightVertical } from './topRight/EditBorderRadiusTop
 
 export const EditBorderRadius = () => {
     // TODO:親のborderRadiusだけ他疑似要素に変更時見た目を保持していない（データは保持できている）
-    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
-    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent)
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent)
     const dispatch = useAppDispatch()
-    let borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let borderRadius = cssStates[uid].cssProps.borderRadius
     if (!borderRadius) {
         borderRadius = ''
     }
-    const uid = getElementUid(selectedElementName, selectedElementClass)
-    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
     const displayBorderRadius = cssStates[uid].customAreaDisplay.borderRadius
     const [borderRadiusAll, setBorderRadiusAll] = useState(borderRadius)
     const [showTooltipAll, setShowTooltipAll] = useState(false)
@@ -46,7 +45,6 @@ export const EditBorderRadius = () => {
 
     const onChangeValue = (v: number) => {
         setBorderRadiusAll(v.toString() + 'px')
-        dispatch(setBorderRadius(v.toString() + 'px'))
         dispatch(
             saveCurrentCssProps({
                 elementName: selectedElementName,

--- a/src/components/cssEditArea/borderRadius/bottomLeft/EditBorderRadiusBottomLeftHorizontal.tsx
+++ b/src/components/cssEditArea/borderRadius/bottomLeft/EditBorderRadiusBottomLeftHorizontal.tsx
@@ -2,13 +2,16 @@ import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, 
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
 import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusBottomLeftHorizontal = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    let borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    if (!borderRadius) {
+        borderRadius = ''
+    }
     const [showTooltipBottomLeftHorizontal, setShowTooltipBottomLeftHorizontal] = useState(false)
     const getBorderRadius = () => {
         const borderRadiusList = borderRadius.split(' ').filter((value) => value !== '/')
@@ -30,14 +33,6 @@ export const EditBorderRadiusBottomLeftHorizontal = memo(() => {
                     classNames: selectedElementClass,
                     cssPropKey: 'borderRadius',
                     cssPropValue: borderRadiusList.join(' '),
-                })
-            )
-            dispatch(
-                saveCurrentCssCodes({
-                    elementName: selectedElementName,
-                    classNames: selectedElementClass,
-                    cssProp: 'borderRadius',
-                    cssValue: borderRadiusList.join(' '),
                 })
             )
         } else {

--- a/src/components/cssEditArea/borderRadius/bottomLeft/EditBorderRadiusBottomLeftHorizontal.tsx
+++ b/src/components/cssEditArea/borderRadius/bottomLeft/EditBorderRadiusBottomLeftHorizontal.tsx
@@ -1,14 +1,15 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusBottomLeftHorizontal = memo(() => {
-    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
-    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent)
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent)
     const dispatch = useAppDispatch()
-    let borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let borderRadius = cssStates[uid].cssProps.borderRadius
     if (!borderRadius) {
         borderRadius = ''
     }
@@ -26,7 +27,6 @@ export const EditBorderRadiusBottomLeftHorizontal = memo(() => {
         if (borderRadiusList.length === 8) {
             borderRadiusList[3] = v.toString() + 'px'
             borderRadiusList.splice(4, 0, '/')
-            dispatch(setBorderRadius(borderRadiusList.join(' ')))
             dispatch(
                 saveCurrentCssProps({
                     elementName: selectedElementName,
@@ -37,9 +37,12 @@ export const EditBorderRadiusBottomLeftHorizontal = memo(() => {
             )
         } else {
             dispatch(
-                setBorderRadius(
-                    `${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius} / ${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius}`
-                )
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssPropKey: 'borderRadius',
+                    cssPropValue: `${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius} / ${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius}`,
+                })
             )
         }
     }

--- a/src/components/cssEditArea/borderRadius/bottomLeft/EditBorderRadiusBottomLeftVertical.tsx
+++ b/src/components/cssEditArea/borderRadius/bottomLeft/EditBorderRadiusBottomLeftVertical.tsx
@@ -1,14 +1,15 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusBottomLeftVertical = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    let borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let borderRadius = cssStates[uid].cssProps.borderRadius
     if (!borderRadius) {
         borderRadius = ''
     }
@@ -26,7 +27,6 @@ export const EditBorderRadiusBottomLeftVertical = memo(() => {
         if (borderRadiusList.length === 8) {
             borderRadiusList[7] = v.toString() + 'px'
             borderRadiusList.splice(4, 0, '/')
-            dispatch(setBorderRadius(borderRadiusList.join(' ')))
             dispatch(
                 saveCurrentCssProps({
                     elementName: selectedElementName,
@@ -37,9 +37,12 @@ export const EditBorderRadiusBottomLeftVertical = memo(() => {
             )
         } else {
             dispatch(
-                setBorderRadius(
-                    `${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius} / ${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius}`
-                )
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssPropKey: 'borderRadius',
+                    cssPropValue: `${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius} / ${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius}`,
+                })
             )
         }
     }

--- a/src/components/cssEditArea/borderRadius/bottomLeft/EditBorderRadiusBottomLeftVertical.tsx
+++ b/src/components/cssEditArea/borderRadius/bottomLeft/EditBorderRadiusBottomLeftVertical.tsx
@@ -2,13 +2,16 @@ import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, 
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
 import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusBottomLeftVertical = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    let borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    if (!borderRadius) {
+        borderRadius = ''
+    }
     const [showTooltipBottomLeftVertical, setShowTooltipBottomLeftVertical] = useState(false)
     const getBorderRadius = () => {
         const borderRadiusList = borderRadius.split(' ').filter((value) => value !== '/')
@@ -30,14 +33,6 @@ export const EditBorderRadiusBottomLeftVertical = memo(() => {
                     classNames: selectedElementClass,
                     cssPropKey: 'borderRadius',
                     cssPropValue: borderRadiusList.join(' '),
-                })
-            )
-            dispatch(
-                saveCurrentCssCodes({
-                    elementName: selectedElementName,
-                    classNames: selectedElementClass,
-                    cssProp: 'borderRadius',
-                    cssValue: borderRadiusList.join(' '),
                 })
             )
         } else {

--- a/src/components/cssEditArea/borderRadius/bottomRight/EditBorderRadiusBottomRightHorizontal.tsx
+++ b/src/components/cssEditArea/borderRadius/bottomRight/EditBorderRadiusBottomRightHorizontal.tsx
@@ -2,13 +2,16 @@ import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, 
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
 import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusBottomRightHorizontal = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    let borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    if (!borderRadius) {
+        borderRadius = ''
+    }
     const [showTooltipBottomRightHorizontal, setShowTooltipBottomRightHorizontal] = useState(false)
     const getBorderRadius = () => {
         const borderRadiusList = borderRadius.split(' ').filter((value) => value !== '/')
@@ -30,14 +33,6 @@ export const EditBorderRadiusBottomRightHorizontal = memo(() => {
                     classNames: selectedElementClass,
                     cssPropKey: 'borderRadius',
                     cssPropValue: borderRadiusList.join(' '),
-                })
-            )
-            dispatch(
-                saveCurrentCssCodes({
-                    elementName: selectedElementName,
-                    classNames: selectedElementClass,
-                    cssProp: 'borderRadius',
-                    cssValue: borderRadiusList.join(' '),
                 })
             )
         } else {

--- a/src/components/cssEditArea/borderRadius/bottomRight/EditBorderRadiusBottomRightHorizontal.tsx
+++ b/src/components/cssEditArea/borderRadius/bottomRight/EditBorderRadiusBottomRightHorizontal.tsx
@@ -1,14 +1,15 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusBottomRightHorizontal = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    let borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let borderRadius = cssStates[uid].cssProps.borderRadius
     if (!borderRadius) {
         borderRadius = ''
     }
@@ -26,7 +27,6 @@ export const EditBorderRadiusBottomRightHorizontal = memo(() => {
         if (borderRadiusList.length === 8) {
             borderRadiusList[2] = v.toString() + 'px'
             borderRadiusList.splice(4, 0, '/')
-            dispatch(setBorderRadius(borderRadiusList.join(' ')))
             dispatch(
                 saveCurrentCssProps({
                     elementName: selectedElementName,
@@ -37,9 +37,12 @@ export const EditBorderRadiusBottomRightHorizontal = memo(() => {
             )
         } else {
             dispatch(
-                setBorderRadius(
-                    `${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius} / ${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius}`
-                )
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssPropKey: 'borderRadius',
+                    cssPropValue: `${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius} / ${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius}`,
+                })
             )
         }
     }

--- a/src/components/cssEditArea/borderRadius/bottomRight/EditBorderRadiusBottomRightVertical.tsx
+++ b/src/components/cssEditArea/borderRadius/bottomRight/EditBorderRadiusBottomRightVertical.tsx
@@ -1,14 +1,15 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusBottomRightVertical = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    let borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let borderRadius = cssStates[uid].cssProps.borderRadius
     if (!borderRadius) {
         borderRadius = ''
     }
@@ -26,7 +27,6 @@ export const EditBorderRadiusBottomRightVertical = memo(() => {
         if (borderRadiusList.length === 8) {
             borderRadiusList[6] = v.toString() + 'px'
             borderRadiusList.splice(4, 0, '/')
-            dispatch(setBorderRadius(borderRadiusList.join(' ')))
             dispatch(
                 saveCurrentCssProps({
                     elementName: selectedElementName,
@@ -37,9 +37,12 @@ export const EditBorderRadiusBottomRightVertical = memo(() => {
             )
         } else {
             dispatch(
-                setBorderRadius(
-                    `${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius} / ${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius}`
-                )
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssPropKey: 'borderRadius',
+                    cssPropValue: `${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius} / ${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius}`,
+                })
             )
         }
     }

--- a/src/components/cssEditArea/borderRadius/bottomRight/EditBorderRadiusBottomRightVertical.tsx
+++ b/src/components/cssEditArea/borderRadius/bottomRight/EditBorderRadiusBottomRightVertical.tsx
@@ -2,13 +2,16 @@ import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, 
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
 import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusBottomRightVertical = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    let borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    if (!borderRadius) {
+        borderRadius = ''
+    }
     const [showTooltipBottomRightVertical, setShowTooltipBottomRightVertical] = useState(false)
     const getBorderRadius = () => {
         const borderRadiusList = borderRadius.split(' ').filter((value) => value !== '/')
@@ -30,14 +33,6 @@ export const EditBorderRadiusBottomRightVertical = memo(() => {
                     classNames: selectedElementClass,
                     cssPropKey: 'borderRadius',
                     cssPropValue: borderRadiusList.join(' '),
-                })
-            )
-            dispatch(
-                saveCurrentCssCodes({
-                    elementName: selectedElementName,
-                    classNames: selectedElementClass,
-                    cssProp: 'borderRadius',
-                    cssValue: borderRadiusList.join(' '),
                 })
             )
         } else {

--- a/src/components/cssEditArea/borderRadius/topLeft/EditBorderRadiusTopLeftHorizontal.tsx
+++ b/src/components/cssEditArea/borderRadius/topLeft/EditBorderRadiusTopLeftHorizontal.tsx
@@ -1,14 +1,15 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusTopLeftHorizontal = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    let borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let borderRadius = cssStates[uid].cssProps.borderRadius
     if (!borderRadius) {
         borderRadius = ''
     }
@@ -26,7 +27,6 @@ export const EditBorderRadiusTopLeftHorizontal = memo(() => {
         if (borderRadiusList.length === 8) {
             borderRadiusList[0] = v.toString() + 'px'
             borderRadiusList.splice(4, 0, '/')
-            dispatch(setBorderRadius(borderRadiusList.join(' ')))
             dispatch(
                 saveCurrentCssProps({
                     elementName: selectedElementName,
@@ -37,9 +37,12 @@ export const EditBorderRadiusTopLeftHorizontal = memo(() => {
             )
         } else {
             dispatch(
-                setBorderRadius(
-                    `${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius} / ${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius}`
-                )
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssPropKey: 'borderRadius',
+                    cssPropValue: `${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius} / ${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius}`,
+                })
             )
         }
     }

--- a/src/components/cssEditArea/borderRadius/topLeft/EditBorderRadiusTopLeftHorizontal.tsx
+++ b/src/components/cssEditArea/borderRadius/topLeft/EditBorderRadiusTopLeftHorizontal.tsx
@@ -2,13 +2,16 @@ import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, 
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
 import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusTopLeftHorizontal = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    let borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    if (!borderRadius) {
+        borderRadius = ''
+    }
     const [showTooltipTopLeftHorizontal, setShowTooltipTopLeftHorizontal] = useState(false)
     const getBorderRadius = () => {
         const borderRadiusList = borderRadius.split(' ').filter((value) => value !== '/')
@@ -30,14 +33,6 @@ export const EditBorderRadiusTopLeftHorizontal = memo(() => {
                     classNames: selectedElementClass,
                     cssPropKey: 'borderRadius',
                     cssPropValue: borderRadiusList.join(' '),
-                })
-            )
-            dispatch(
-                saveCurrentCssCodes({
-                    elementName: selectedElementName,
-                    classNames: selectedElementClass,
-                    cssProp: 'borderRadius',
-                    cssValue: borderRadiusList.join(' '),
                 })
             )
         } else {

--- a/src/components/cssEditArea/borderRadius/topLeft/EditBorderRadiusTopLeftVertical.tsx
+++ b/src/components/cssEditArea/borderRadius/topLeft/EditBorderRadiusTopLeftVertical.tsx
@@ -2,13 +2,16 @@ import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, 
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
 import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusTopLeftVertical = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    let borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    if (!borderRadius) {
+        borderRadius = ''
+    }
     const [showTooltipTopLeftVertical, setShowTooltipTopLeftVertical] = useState(false)
     const getBorderRadius = () => {
         const borderRadiusList = borderRadius.split(' ').filter((value) => value !== '/')
@@ -30,14 +33,6 @@ export const EditBorderRadiusTopLeftVertical = memo(() => {
                     classNames: selectedElementClass,
                     cssPropKey: 'borderRadius',
                     cssPropValue: borderRadiusList.join(' '),
-                })
-            )
-            dispatch(
-                saveCurrentCssCodes({
-                    elementName: selectedElementName,
-                    classNames: selectedElementClass,
-                    cssProp: 'borderRadius',
-                    cssValue: borderRadiusList.join(' '),
                 })
             )
         } else {

--- a/src/components/cssEditArea/borderRadius/topLeft/EditBorderRadiusTopLeftVertical.tsx
+++ b/src/components/cssEditArea/borderRadius/topLeft/EditBorderRadiusTopLeftVertical.tsx
@@ -1,14 +1,15 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusTopLeftVertical = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    let borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let borderRadius = cssStates[uid].cssProps.borderRadius
     if (!borderRadius) {
         borderRadius = ''
     }
@@ -26,7 +27,6 @@ export const EditBorderRadiusTopLeftVertical = memo(() => {
         if (borderRadiusList.length === 8) {
             borderRadiusList[4] = v.toString() + 'px'
             borderRadiusList.splice(4, 0, '/')
-            dispatch(setBorderRadius(borderRadiusList.join(' ')))
             dispatch(
                 saveCurrentCssProps({
                     elementName: selectedElementName,
@@ -37,9 +37,12 @@ export const EditBorderRadiusTopLeftVertical = memo(() => {
             )
         } else {
             dispatch(
-                setBorderRadius(
-                    `${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius} / ${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius}`
-                )
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssPropKey: 'borderRadius',
+                    cssPropValue: `${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius} / ${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius}`,
+                })
             )
         }
     }

--- a/src/components/cssEditArea/borderRadius/topRight/EditBorderRadiusTopRightHorizontal.tsx
+++ b/src/components/cssEditArea/borderRadius/topRight/EditBorderRadiusTopRightHorizontal.tsx
@@ -1,14 +1,15 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusTopRightHorizontal = memo(() => {
-    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
-    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent)
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent)
     const dispatch = useAppDispatch()
-    let borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let borderRadius = cssStates[uid].cssProps.borderRadius
     if (!borderRadius) {
         borderRadius = ''
     }
@@ -26,7 +27,6 @@ export const EditBorderRadiusTopRightHorizontal = memo(() => {
         if (borderRadiusList.length === 8) {
             borderRadiusList[1] = v.toString() + 'px'
             borderRadiusList.splice(4, 0, '/')
-            dispatch(setBorderRadius(borderRadiusList.join(' ')))
             dispatch(
                 saveCurrentCssProps({
                     elementName: selectedElementName,
@@ -37,9 +37,12 @@ export const EditBorderRadiusTopRightHorizontal = memo(() => {
             )
         } else {
             dispatch(
-                setBorderRadius(
-                    `${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius} / ${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius}`
-                )
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssPropKey: 'borderRadius',
+                    cssPropValue: `${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius} / ${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius}`,
+                })
             )
         }
     }

--- a/src/components/cssEditArea/borderRadius/topRight/EditBorderRadiusTopRightHorizontal.tsx
+++ b/src/components/cssEditArea/borderRadius/topRight/EditBorderRadiusTopRightHorizontal.tsx
@@ -2,13 +2,16 @@ import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, 
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
 import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusTopRightHorizontal = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    let borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    if (!borderRadius) {
+        borderRadius = ''
+    }
     const [showTooltipTopRightHorizontal, setShowTooltipTopRightHorizontal] = useState(false)
     const getBorderRadius = () => {
         const borderRadiusList = borderRadius.split(' ').filter((value) => value !== '/')
@@ -30,14 +33,6 @@ export const EditBorderRadiusTopRightHorizontal = memo(() => {
                     classNames: selectedElementClass,
                     cssPropKey: 'borderRadius',
                     cssPropValue: borderRadiusList.join(' '),
-                })
-            )
-            dispatch(
-                saveCurrentCssCodes({
-                    elementName: selectedElementName,
-                    classNames: selectedElementClass,
-                    cssProp: 'borderRadius',
-                    cssValue: borderRadiusList.join(' '),
                 })
             )
         } else {

--- a/src/components/cssEditArea/borderRadius/topRight/EditBorderRadiusTopRightVertical.tsx
+++ b/src/components/cssEditArea/borderRadius/topRight/EditBorderRadiusTopRightVertical.tsx
@@ -2,13 +2,16 @@ import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, 
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
 import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusTopRightVertical = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    let borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    if (!borderRadius) {
+        borderRadius = ''
+    }
     const [showTooltipTopRightVertical, setShowTooltipTopRightVertical] = useState(false)
     const getBorderRadius = () => {
         const borderRadiusList = borderRadius.split(' ').filter((value) => value !== '/')
@@ -30,14 +33,6 @@ export const EditBorderRadiusTopRightVertical = memo(() => {
                     classNames: selectedElementClass,
                     cssPropKey: 'borderRadius',
                     cssPropValue: borderRadiusList.join(' '),
-                })
-            )
-            dispatch(
-                saveCurrentCssCodes({
-                    elementName: selectedElementName,
-                    classNames: selectedElementClass,
-                    cssProp: 'borderRadius',
-                    cssValue: borderRadiusList.join(' '),
                 })
             )
         } else {

--- a/src/components/cssEditArea/borderRadius/topRight/EditBorderRadiusTopRightVertical.tsx
+++ b/src/components/cssEditArea/borderRadius/topRight/EditBorderRadiusTopRightVertical.tsx
@@ -1,14 +1,15 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderRadius } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderRadiusTopRightVertical = memo(() => {
-    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
-    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent)
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent)
     const dispatch = useAppDispatch()
-    let borderRadius = useAppSelector((state) => state.buttonView.borderRadius)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let borderRadius = cssStates[uid].cssProps.borderRadius
     if (!borderRadius) {
         borderRadius = ''
     }
@@ -26,7 +27,6 @@ export const EditBorderRadiusTopRightVertical = memo(() => {
         if (borderRadiusList.length === 8) {
             borderRadiusList[5] = v.toString() + 'px'
             borderRadiusList.splice(4, 0, '/')
-            dispatch(setBorderRadius(borderRadiusList.join(' ')))
             dispatch(
                 saveCurrentCssProps({
                     elementName: selectedElementName,
@@ -37,9 +37,12 @@ export const EditBorderRadiusTopRightVertical = memo(() => {
             )
         } else {
             dispatch(
-                setBorderRadius(
-                    `${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius} / ${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius}`
-                )
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssPropKey: 'borderRadius',
+                    cssPropValue: `${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius} / ${borderRadius} ${borderRadius} ${borderRadius} ${borderRadius}`,
+                })
             )
         }
     }

--- a/src/components/cssEditArea/borderStyle/EditBorderStyle.tsx
+++ b/src/components/cssEditArea/borderStyle/EditBorderStyle.tsx
@@ -4,7 +4,7 @@ import { motion } from 'framer-motion'
 import React, { useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
 import { setBorderStyle } from '../../buttonView/buttonViewSlice'
-import { getElementUid, saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
 import { rotateElementVariants } from '../animation/rotateElement'
 
@@ -13,9 +13,12 @@ export const EditBorderStyle = () => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const borderStyle = useAppSelector((state) => state.buttonView.borderStyle)
     const uid = getElementUid(selectedElementName, selectedElementClass)
     const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
+    let borderStyle = useAppSelector((state) => state.buttonView.borderStyle)
+    if (!borderStyle) {
+        borderStyle = ''
+    }
     const displayBorderStyle = cssStates[uid].customAreaDisplay.borderStyle
     const [isDisplayDetail, setIsDisplayDetail] = useState(false)
     const onClickBorderStyle = (style: string) => {
@@ -26,14 +29,6 @@ export const EditBorderStyle = () => {
                 classNames: selectedElementClass,
                 cssPropKey: 'borderStyle',
                 cssPropValue: style,
-            })
-        )
-        dispatch(
-            saveCurrentCssCodes({
-                elementName: selectedElementName,
-                classNames: selectedElementClass,
-                cssProp: 'borderStyle',
-                cssValue: style,
             })
         )
     }
@@ -93,14 +88,6 @@ export const EditBorderStyle = () => {
                 classNames: selectedElementClass,
                 cssPropKey: 'borderStyle',
                 cssPropValue: newBorderStyle,
-            })
-        )
-        dispatch(
-            saveCurrentCssCodes({
-                elementName: selectedElementName,
-                classNames: selectedElementClass,
-                cssProp: 'borderStyle',
-                cssValue: newBorderStyle,
             })
         )
     }

--- a/src/components/cssEditArea/borderStyle/EditBorderStyle.tsx
+++ b/src/components/cssEditArea/borderStyle/EditBorderStyle.tsx
@@ -3,26 +3,24 @@ import { Flex, Button, Box, Text } from '@chakra-ui/react'
 import { motion } from 'framer-motion'
 import React, { useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setBorderStyle } from '../../buttonView/buttonViewSlice'
 import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
 import { rotateElementVariants } from '../animation/rotateElement'
 
 export const EditBorderStyle = () => {
     // TODO:でかすぎ
-    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
-    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent)
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent)
     const dispatch = useAppDispatch()
     const uid = getElementUid(selectedElementName, selectedElementClass)
-    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
-    let borderStyle = useAppSelector((state) => state.buttonView.borderStyle)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let borderStyle = cssStates[uid].cssProps.borderStyle
     if (!borderStyle) {
         borderStyle = ''
     }
     const displayBorderStyle = cssStates[uid].customAreaDisplay.borderStyle
     const [isDisplayDetail, setIsDisplayDetail] = useState(false)
     const onClickBorderStyle = (style: string) => {
-        dispatch(setBorderStyle(style))
         dispatch(
             saveCurrentCssProps({
                 elementName: selectedElementName,
@@ -56,16 +54,44 @@ export const EditBorderStyle = () => {
         let newBorderStyle = ''
         if (borderStyleList.length === 1) {
             if (position === 'top') {
-                dispatch(setBorderStyle(`${_borderStyle} ${borderStyle} ${borderStyle} ${borderStyle}`))
+                dispatch(
+                    saveCurrentCssProps({
+                        elementName: selectedElementName,
+                        classNames: selectedElementClass,
+                        cssPropKey: 'borderStyle',
+                        cssPropValue: `${_borderStyle} ${borderStyle} ${borderStyle} ${borderStyle}`,
+                    })
+                )
                 newBorderStyle = `${_borderStyle} ${borderStyle} ${borderStyle} ${borderStyle}`
             } else if (position === 'right') {
-                dispatch(setBorderStyle(`${borderStyle} ${_borderStyle} ${borderStyle} ${borderStyle}`))
+                dispatch(
+                    saveCurrentCssProps({
+                        elementName: selectedElementName,
+                        classNames: selectedElementClass,
+                        cssPropKey: 'borderStyle',
+                        cssPropValue: `${borderStyle} ${_borderStyle} ${borderStyle} ${borderStyle}`,
+                    })
+                )
                 newBorderStyle = `${borderStyle} ${_borderStyle} ${borderStyle} ${borderStyle}`
             } else if (position === 'bottom') {
-                dispatch(setBorderStyle(`${borderStyle} ${borderStyle} ${_borderStyle} ${borderStyle}`))
+                dispatch(
+                    saveCurrentCssProps({
+                        elementName: selectedElementName,
+                        classNames: selectedElementClass,
+                        cssPropKey: 'borderStyle',
+                        cssPropValue: `${borderStyle} ${borderStyle} ${_borderStyle} ${borderStyle}`,
+                    })
+                )
                 newBorderStyle = `${borderStyle} ${borderStyle} ${_borderStyle} ${borderStyle}`
             } else if (position === 'left') {
-                dispatch(setBorderStyle(`${borderStyle} ${borderStyle} ${borderStyle} ${_borderStyle}`))
+                dispatch(
+                    saveCurrentCssProps({
+                        elementName: selectedElementName,
+                        classNames: selectedElementClass,
+                        cssPropKey: 'borderStyle',
+                        cssPropValue: `${borderStyle} ${borderStyle} ${borderStyle} ${_borderStyle}`,
+                    })
+                )
                 newBorderStyle = `${borderStyle} ${borderStyle} ${borderStyle} ${_borderStyle}`
             }
         } else {
@@ -79,7 +105,14 @@ export const EditBorderStyle = () => {
                 borderStyleList[3] = _borderStyle
             }
             const borderStyleStrings = borderStyleList.join(' ')
-            dispatch(setBorderStyle(borderStyleStrings))
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssPropKey: 'borderStyle',
+                    cssPropValue: borderStyleStrings,
+                })
+            )
             newBorderStyle = borderStyleList.join(' ')
         }
         dispatch(

--- a/src/components/cssEditArea/borderWidth/EditBorderWidth.tsx
+++ b/src/components/cssEditArea/borderWidth/EditBorderWidth.tsx
@@ -12,7 +12,6 @@ import {
     Box,
 } from '@chakra-ui/react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setBorderWidth } from '../../buttonView/buttonViewSlice'
 import { AddIcon } from '@chakra-ui/icons'
 import { motion } from 'framer-motion'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
@@ -24,12 +23,12 @@ import { EditBorderWidthLeft } from './borderWidthLeft/EditBorderWidthLeft'
 import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderWidth = () => {
-    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
-    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent)
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent)
     const dispatch = useAppDispatch()
     const uid = getElementUid(selectedElementName, selectedElementClass)
-    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
-    let borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let borderWidth = cssStates[uid].cssProps.borderWidth
     if (!borderWidth) {
         borderWidth = ''
     }
@@ -41,7 +40,6 @@ export const EditBorderWidth = () => {
     const onChangeValue = (v: number) => {
         // TODO:親のborderWidthだけ他疑似要素に変更時見た目を保持していない（データは保持できている）
         setAllBorderWidth(v.toString() + 'px')
-        dispatch(setBorderWidth(v.toString() + 'px'))
         dispatch(
             saveCurrentCssProps({
                 elementName: selectedElementName,

--- a/src/components/cssEditArea/borderWidth/EditBorderWidth.tsx
+++ b/src/components/cssEditArea/borderWidth/EditBorderWidth.tsx
@@ -21,15 +21,18 @@ import { EditBorderWidthTop } from './borderWidthTop/EditBorderWidthTop'
 import { EditBorderWidthRight } from './borderWidthRight/EditBorderWidthRight'
 import { EditBorderWidthBottom } from './borderWidthBottom/EditBorderWidthBottom'
 import { EditBorderWidthLeft } from './borderWidthLeft/EditBorderWidthLeft'
-import { getElementUid, saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderWidth = () => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
     const uid = getElementUid(selectedElementName, selectedElementClass)
     const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
+    let borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
+    if (!borderWidth) {
+        borderWidth = ''
+    }
     const displayBorderWidth = cssStates[uid].customAreaDisplay.borderWidth
     const [showTooltip, setShowTooltip] = useState(false)
     const [isDisplayDetail, setIsDisplayDetail] = useState(false)
@@ -45,14 +48,6 @@ export const EditBorderWidth = () => {
                 classNames: selectedElementClass,
                 cssPropKey: 'borderWidth',
                 cssPropValue: v.toString() + 'px',
-            })
-        )
-        dispatch(
-            saveCurrentCssCodes({
-                elementName: selectedElementName,
-                classNames: selectedElementClass,
-                cssProp: 'borderWidth',
-                cssValue: v.toString() + 'px',
             })
         )
     }

--- a/src/components/cssEditArea/borderWidth/borderWidthBottom/EditBorderWidthBottom.tsx
+++ b/src/components/cssEditArea/borderWidth/borderWidthBottom/EditBorderWidthBottom.tsx
@@ -2,13 +2,16 @@ import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, 
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
 import { setBorderWidth } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderWidthBottom = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
+    let borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
+    if (!borderWidth) {
+        borderWidth = ''
+    }
     const [showTooltipBorderWidthBottom, setShowTooltipBorderWidthBottom] = useState(false)
     const getBorderWidth = () => {
         const borderWidthList = borderWidth.split(' ')
@@ -29,14 +32,6 @@ export const EditBorderWidthBottom = memo(() => {
                     classNames: selectedElementClass,
                     cssPropKey: 'borderWidth',
                     cssPropValue: borderWidthList.join(' '),
-                })
-            )
-            dispatch(
-                saveCurrentCssCodes({
-                    elementName: selectedElementName,
-                    classNames: selectedElementClass,
-                    cssProp: 'borderWidth',
-                    cssValue: borderWidthList.join(' '),
                 })
             )
         } else {

--- a/src/components/cssEditArea/borderWidth/borderWidthBottom/EditBorderWidthBottom.tsx
+++ b/src/components/cssEditArea/borderWidth/borderWidthBottom/EditBorderWidthBottom.tsx
@@ -1,14 +1,15 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderWidth } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderWidthBottom = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    let borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let borderWidth = cssStates[uid].cssProps.borderWidth
     if (!borderWidth) {
         borderWidth = ''
     }
@@ -25,7 +26,6 @@ export const EditBorderWidthBottom = memo(() => {
         const borderWidthList = borderWidth.split(' ')
         if (borderWidthList.length === 4) {
             borderWidthList[2] = v.toString() + 'px'
-            dispatch(setBorderWidth(borderWidthList.join(' ')))
             dispatch(
                 saveCurrentCssProps({
                     elementName: selectedElementName,
@@ -35,7 +35,14 @@ export const EditBorderWidthBottom = memo(() => {
                 })
             )
         } else {
-            dispatch(setBorderWidth(`${borderWidth} ${borderWidth} ${borderWidth} ${borderWidth}`))
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssPropKey: 'borderWidth',
+                    cssPropValue: `${borderWidth} ${borderWidth} ${borderWidth} ${borderWidth}`,
+                })
+            )
         }
     }
     return (

--- a/src/components/cssEditArea/borderWidth/borderWidthLeft/EditBorderWidthLeft.tsx
+++ b/src/components/cssEditArea/borderWidth/borderWidthLeft/EditBorderWidthLeft.tsx
@@ -1,14 +1,15 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderWidth } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderWidthLeft = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    let borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let borderWidth = cssStates[uid].cssProps.borderWidth
     if (!borderWidth) {
         borderWidth = ''
     }
@@ -25,7 +26,6 @@ export const EditBorderWidthLeft = memo(() => {
         const borderWidthList = borderWidth.split(' ')
         if (borderWidthList.length === 4) {
             borderWidthList[3] = v.toString() + 'px'
-            dispatch(setBorderWidth(borderWidthList.join(' ')))
             dispatch(
                 saveCurrentCssProps({
                     elementName: selectedElementName,
@@ -35,7 +35,14 @@ export const EditBorderWidthLeft = memo(() => {
                 })
             )
         } else {
-            dispatch(setBorderWidth(`${borderWidth} ${borderWidth} ${borderWidth} ${borderWidth}`))
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssPropKey: 'borderWidth',
+                    cssPropValue: `${borderWidth} ${borderWidth} ${borderWidth} ${borderWidth}`,
+                })
+            )
         }
     }
     return (

--- a/src/components/cssEditArea/borderWidth/borderWidthLeft/EditBorderWidthLeft.tsx
+++ b/src/components/cssEditArea/borderWidth/borderWidthLeft/EditBorderWidthLeft.tsx
@@ -2,13 +2,16 @@ import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, 
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
 import { setBorderWidth } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderWidthLeft = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
+    let borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
+    if (!borderWidth) {
+        borderWidth = ''
+    }
     const [showTooltipBorderWidthLeft, setShowTooltipBorderWidthLeft] = useState(false)
     const getBorderWidth = () => {
         const borderWidthList = borderWidth.split(' ')
@@ -29,14 +32,6 @@ export const EditBorderWidthLeft = memo(() => {
                     classNames: selectedElementClass,
                     cssPropKey: 'borderWidth',
                     cssPropValue: borderWidthList.join(' '),
-                })
-            )
-            dispatch(
-                saveCurrentCssCodes({
-                    elementName: selectedElementName,
-                    classNames: selectedElementClass,
-                    cssProp: 'borderWidth',
-                    cssValue: borderWidthList.join(' '),
                 })
             )
         } else {

--- a/src/components/cssEditArea/borderWidth/borderWidthRight/EditBorderWidthRight.tsx
+++ b/src/components/cssEditArea/borderWidth/borderWidthRight/EditBorderWidthRight.tsx
@@ -2,13 +2,16 @@ import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, 
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
 import { setBorderWidth } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderWidthRight = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
+    let borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
+    if (!borderWidth) {
+        borderWidth = ''
+    }
     const [showTooltipBorderWidthRight, setShowTooltipBorderWidthRight] = useState(false)
     const getBorderWidth = () => {
         const borderWidthList = borderWidth.split(' ')
@@ -29,14 +32,6 @@ export const EditBorderWidthRight = memo(() => {
                     classNames: selectedElementClass,
                     cssPropKey: 'borderWidth',
                     cssPropValue: borderWidthList.join(' '),
-                })
-            )
-            dispatch(
-                saveCurrentCssCodes({
-                    elementName: selectedElementName,
-                    classNames: selectedElementClass,
-                    cssProp: 'borderWidth',
-                    cssValue: borderWidthList.join(' '),
                 })
             )
         } else {

--- a/src/components/cssEditArea/borderWidth/borderWidthRight/EditBorderWidthRight.tsx
+++ b/src/components/cssEditArea/borderWidth/borderWidthRight/EditBorderWidthRight.tsx
@@ -1,14 +1,15 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderWidth } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderWidthRight = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    let borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let borderWidth = cssStates[uid].cssProps.borderWidth
     if (!borderWidth) {
         borderWidth = ''
     }
@@ -25,7 +26,6 @@ export const EditBorderWidthRight = memo(() => {
         const borderWidthList = borderWidth.split(' ')
         if (borderWidthList.length === 4) {
             borderWidthList[1] = v.toString() + 'px'
-            dispatch(setBorderWidth(borderWidthList.join(' ')))
             dispatch(
                 saveCurrentCssProps({
                     elementName: selectedElementName,
@@ -35,7 +35,14 @@ export const EditBorderWidthRight = memo(() => {
                 })
             )
         } else {
-            dispatch(setBorderWidth(`${borderWidth} ${borderWidth} ${borderWidth} ${borderWidth}`))
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssPropKey: 'borderWidth',
+                    cssPropValue: `${borderWidth} ${borderWidth} ${borderWidth} ${borderWidth}`,
+                })
+            )
         }
     }
     return (

--- a/src/components/cssEditArea/borderWidth/borderWidthTop/EditBorderWidthTop.tsx
+++ b/src/components/cssEditArea/borderWidth/borderWidthTop/EditBorderWidthTop.tsx
@@ -1,14 +1,15 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setBorderWidth } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderWidthTop = memo(() => {
-    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
-    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent)
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent)
     const dispatch = useAppDispatch()
-    let borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let borderWidth = cssStates[uid].cssProps.borderWidth
     if (!borderWidth) {
         borderWidth = ''
     }
@@ -25,7 +26,6 @@ export const EditBorderWidthTop = memo(() => {
         const borderWidthList = borderWidth.split(' ')
         if (borderWidthList.length === 4) {
             borderWidthList[0] = v.toString() + 'px'
-            dispatch(setBorderWidth(borderWidthList.join(' ')))
             dispatch(
                 saveCurrentCssProps({
                     elementName: selectedElementName,
@@ -35,7 +35,14 @@ export const EditBorderWidthTop = memo(() => {
                 })
             )
         } else {
-            dispatch(setBorderWidth(`${borderWidth} ${borderWidth} ${borderWidth} ${borderWidth}`))
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssPropKey: 'borderWidth',
+                    cssPropValue: `${borderWidth} ${borderWidth} ${borderWidth} ${borderWidth}`,
+                })
+            )
         }
     }
     return (

--- a/src/components/cssEditArea/borderWidth/borderWidthTop/EditBorderWidthTop.tsx
+++ b/src/components/cssEditArea/borderWidth/borderWidthTop/EditBorderWidthTop.tsx
@@ -2,13 +2,16 @@ import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, 
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
 import { setBorderWidth } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditBorderWidthTop = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
+    let borderWidth = useAppSelector((state) => state.buttonView.borderWidth)
+    if (!borderWidth) {
+        borderWidth = ''
+    }
     const [showTooltipBorderWidthTop, setShowTooltipBorderWidthTop] = useState(false)
     const getBorderWidth = () => {
         const borderWidthList = borderWidth.split(' ')
@@ -29,14 +32,6 @@ export const EditBorderWidthTop = memo(() => {
                     classNames: selectedElementClass,
                     cssPropKey: 'borderWidth',
                     cssPropValue: borderWidthList.join(' '),
-                })
-            )
-            dispatch(
-                saveCurrentCssCodes({
-                    elementName: selectedElementName,
-                    classNames: selectedElementClass,
-                    cssProp: 'borderWidth',
-                    cssValue: borderWidthList.join(' '),
                 })
             )
         } else {

--- a/src/components/cssEditArea/color/EditColor.tsx
+++ b/src/components/cssEditArea/color/EditColor.tsx
@@ -5,7 +5,7 @@ import React, { useState } from 'react'
 import { AlphaPicker, ChromePicker, ColorResult, HuePicker } from 'react-color'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
 import { setColor } from '../../buttonView/buttonViewSlice'
-import { getElementUid, saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
 import { rotateElementVariants } from '../animation/rotateElement'
 
@@ -13,9 +13,12 @@ export const EditColor = () => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const colorRgb = useAppSelector((state) => state.buttonView.color)
     const uid = getElementUid(selectedElementName, selectedElementClass)
     const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
+    let colorRgb = useAppSelector((state) => state.buttonView.color)
+    if (!colorRgb) {
+        colorRgb = ''
+    }
     const displayColor = cssStates[uid].customAreaDisplay.color
     const [isDisplayDetail, setIsDisplayDetail] = useState(false)
     const handleChange = (color: ColorResult) => {
@@ -27,14 +30,6 @@ export const EditColor = () => {
                 classNames: selectedElementClass,
                 cssPropKey: 'color',
                 cssPropValue: rgba,
-            })
-        )
-        dispatch(
-            saveCurrentCssCodes({
-                elementName: selectedElementName,
-                classNames: selectedElementClass,
-                cssProp: 'color',
-                cssValue: rgba,
             })
         )
     }

--- a/src/components/cssEditArea/color/EditColor.tsx
+++ b/src/components/cssEditArea/color/EditColor.tsx
@@ -4,7 +4,6 @@ import { motion } from 'framer-motion'
 import React, { useState } from 'react'
 import { AlphaPicker, ChromePicker, ColorResult, HuePicker } from 'react-color'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setColor } from '../../buttonView/buttonViewSlice'
 import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
 import { rotateElementVariants } from '../animation/rotateElement'
@@ -15,7 +14,7 @@ export const EditColor = () => {
     const dispatch = useAppDispatch()
     const uid = getElementUid(selectedElementName, selectedElementClass)
     const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
-    let colorRgb = useAppSelector((state) => state.buttonView.color)
+    let colorRgb = cssStates[uid].cssProps.color
     if (!colorRgb) {
         colorRgb = ''
     }
@@ -23,7 +22,6 @@ export const EditColor = () => {
     const [isDisplayDetail, setIsDisplayDetail] = useState(false)
     const handleChange = (color: ColorResult) => {
         const rgba = `rgba(${color.rgb.r},${color.rgb.g},${color.rgb.b},${color.rgb.a})`
-        dispatch(setColor(rgba))
         dispatch(
             saveCurrentCssProps({
                 elementName: selectedElementName,

--- a/src/components/cssEditArea/fontSize/FontSize.tsx
+++ b/src/components/cssEditArea/fontSize/FontSize.tsx
@@ -2,13 +2,16 @@ import React, { useState } from 'react'
 import { Slider, SliderTrack, SliderFilledTrack, SliderThumb, SliderMark, Tooltip, Flex, Text } from '@chakra-ui/react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
 import { setFontSize } from '../../buttonView/buttonViewSlice'
-import { getElementUid, saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 
 export const FontSize = () => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const fontSize = useAppSelector((state) => state.buttonView.fontSize)
+    let fontSize = useAppSelector((state) => state.buttonView.fontSize)
+    if (!fontSize) {
+        fontSize = ''
+    }
     const [showTooltip, setShowTooltip] = useState(false)
     const uid = getElementUid(selectedElementName, selectedElementClass)
     const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
@@ -21,14 +24,6 @@ export const FontSize = () => {
                 classNames: selectedElementClass,
                 cssPropKey: 'fontSize',
                 cssPropValue: v.toString() + 'px',
-            })
-        )
-        dispatch(
-            saveCurrentCssCodes({
-                elementName: selectedElementName,
-                classNames: selectedElementClass,
-                cssProp: 'fontSize',
-                cssValue: v.toString() + 'px',
             })
         )
     }

--- a/src/components/cssEditArea/fontSize/FontSize.tsx
+++ b/src/components/cssEditArea/fontSize/FontSize.tsx
@@ -1,23 +1,21 @@
 import React, { useState } from 'react'
 import { Slider, SliderTrack, SliderFilledTrack, SliderThumb, SliderMark, Tooltip, Flex, Text } from '@chakra-ui/react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setFontSize } from '../../buttonView/buttonViewSlice'
 import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 
 export const FontSize = () => {
-    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
-    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent)
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent)
     const dispatch = useAppDispatch()
-    let fontSize = useAppSelector((state) => state.buttonView.fontSize)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let fontSize = cssStates[uid].cssProps.fontSize
     if (!fontSize) {
         fontSize = ''
     }
     const [showTooltip, setShowTooltip] = useState(false)
-    const uid = getElementUid(selectedElementName, selectedElementClass)
-    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
     const displayFontSize = cssStates[uid].customAreaDisplay.fontSize
     const onChangeValue = (v: number) => {
-        dispatch(setFontSize(v.toString() + 'px'))
         dispatch(
             saveCurrentCssProps({
                 elementName: selectedElementName,

--- a/src/components/cssEditArea/height/EditHeight.tsx
+++ b/src/components/cssEditArea/height/EditHeight.tsx
@@ -2,14 +2,17 @@ import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, 
 import React, { useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
 import { setHeight } from '../../buttonView/buttonViewSlice'
-import { getElementUid, saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 
 export const EditHeight = () => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const [showTooltip, setShowTooltip] = useState(false)
     const dispatch = useAppDispatch()
-    const height = useAppSelector((state) => state.buttonView.height)
+    let height = useAppSelector((state) => state.buttonView.height)
+    if (!height) {
+        height = ''
+    }
     const uid = getElementUid(selectedElementName, selectedElementClass)
     const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
     const displayHeight = cssStates[uid].customAreaDisplay.height
@@ -21,14 +24,6 @@ export const EditHeight = () => {
                 classNames: selectedElementClass,
                 cssPropKey: 'height',
                 cssPropValue: v.toString() + 'px',
-            })
-        )
-        dispatch(
-            saveCurrentCssCodes({
-                elementName: selectedElementName,
-                classNames: selectedElementClass,
-                cssProp: 'height',
-                cssValue: v.toString() + 'px',
             })
         )
     }

--- a/src/components/cssEditArea/height/EditHeight.tsx
+++ b/src/components/cssEditArea/height/EditHeight.tsx
@@ -1,23 +1,21 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setHeight } from '../../buttonView/buttonViewSlice'
 import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 
 export const EditHeight = () => {
-    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
-    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent)
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent)
     const [showTooltip, setShowTooltip] = useState(false)
     const dispatch = useAppDispatch()
-    let height = useAppSelector((state) => state.buttonView.height)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let height = cssStates[uid].cssProps.height
     if (!height) {
         height = ''
     }
-    const uid = getElementUid(selectedElementName, selectedElementClass)
-    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
     const displayHeight = cssStates[uid].customAreaDisplay.height
     const onChangeValue = (v: number) => {
-        dispatch(setHeight(v.toString() + 'px'))
         dispatch(
             saveCurrentCssProps({
                 elementName: selectedElementName,

--- a/src/components/cssEditArea/padding/Padding.tsx
+++ b/src/components/cssEditArea/padding/Padding.tsx
@@ -21,15 +21,18 @@ import { EditPaddingTop } from './paddingTop/EditPaddingTop'
 import { EditPaddingRight } from './paddingRight/EditPaddingRight'
 import { EditPaddingBottom } from './paddingBottom/EditPaddingBottom'
 import { EditPaddingLeft } from './paddingLeft/EditPaddingLeft'
-import { getElementUid, saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 
 export const Padding = () => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
     const dispatch = useAppDispatch()
-    const padding = useAppSelector((state) => state.buttonView.padding)
     const uid = getElementUid(selectedElementName, selectedElementClass)
     const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
+    let padding = cssStates[uid].cssProps.padding
+    if (!padding) {
+        padding = ''
+    }
     const displayPadding = cssStates[uid].customAreaDisplay.padding
     const [showTooltip, setShowTooltip] = useState(false)
     const [isDisplayDetail, setIsDisplayDetail] = useState(false)
@@ -45,14 +48,6 @@ export const Padding = () => {
                 classNames: selectedElementClass,
                 cssPropKey: 'padding',
                 cssPropValue: v.toString() + 'px',
-            })
-        )
-        dispatch(
-            saveCurrentCssCodes({
-                elementName: selectedElementName,
-                classNames: selectedElementClass,
-                cssProp: 'padding',
-                cssValue: v.toString() + 'px',
             })
         )
     }

--- a/src/components/cssEditArea/padding/Padding.tsx
+++ b/src/components/cssEditArea/padding/Padding.tsx
@@ -12,7 +12,6 @@ import {
     Box,
 } from '@chakra-ui/react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setPadding } from '../../buttonView/buttonViewSlice'
 import { AddIcon } from '@chakra-ui/icons'
 import { motion } from 'framer-motion'
 import { addCssButtonAnimeVariants } from '../animation/addCssButton'
@@ -24,11 +23,11 @@ import { EditPaddingLeft } from './paddingLeft/EditPaddingLeft'
 import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 
 export const Padding = () => {
-    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
-    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent)
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent)
     const dispatch = useAppDispatch()
     const uid = getElementUid(selectedElementName, selectedElementClass)
-    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
     let padding = cssStates[uid].cssProps.padding
     if (!padding) {
         padding = ''
@@ -41,7 +40,6 @@ export const Padding = () => {
     const onChangeValue = (v: number) => {
         // TODO:親のpaddingだけ他疑似要素に変更時見た目を保持していない（データは保持できている）
         setAllPadding(v.toString() + 'px')
-        dispatch(setPadding(v.toString() + 'px'))
         dispatch(
             saveCurrentCssProps({
                 elementName: selectedElementName,

--- a/src/components/cssEditArea/padding/paddingBottom/EditPaddingBottom.tsx
+++ b/src/components/cssEditArea/padding/paddingBottom/EditPaddingBottom.tsx
@@ -1,14 +1,18 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setPadding } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditPaddingBottom = memo(() => {
-    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
-    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent)
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent)
     const dispatch = useAppDispatch()
-    const padding = useAppSelector((state) => state.buttonView.padding)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let padding = cssStates[uid].cssProps.padding
+    if (!padding) {
+        padding = ''
+    }
     const [showTooltipPaddingBottom, setShowTooltipPaddingBottom] = useState(false)
     const getPadding = () => {
         const paddingList = padding.split(' ')
@@ -22,7 +26,6 @@ export const EditPaddingBottom = memo(() => {
         const paddingList = padding.split(' ')
         if (paddingList.length === 4) {
             paddingList[2] = v.toString() + 'px'
-            dispatch(setPadding(paddingList.join(' ')))
             dispatch(
                 saveCurrentCssProps({
                     elementName: selectedElementName,
@@ -32,7 +35,14 @@ export const EditPaddingBottom = memo(() => {
                 })
             )
         } else {
-            dispatch(setPadding(`${padding} ${padding} ${padding} ${padding}`))
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssPropKey: 'padding',
+                    cssPropValue: `${padding} ${padding} ${padding} ${padding}`,
+                })
+            )
         }
     }
     return (

--- a/src/components/cssEditArea/padding/paddingBottom/EditPaddingBottom.tsx
+++ b/src/components/cssEditArea/padding/paddingBottom/EditPaddingBottom.tsx
@@ -2,7 +2,7 @@ import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, 
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
 import { setPadding } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditPaddingBottom = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
@@ -29,14 +29,6 @@ export const EditPaddingBottom = memo(() => {
                     classNames: selectedElementClass,
                     cssPropKey: 'padding',
                     cssPropValue: paddingList.join(' '),
-                })
-            )
-            dispatch(
-                saveCurrentCssCodes({
-                    elementName: selectedElementName,
-                    classNames: selectedElementClass,
-                    cssProp: 'padding',
-                    cssValue: paddingList.join(' '),
                 })
             )
         } else {

--- a/src/components/cssEditArea/padding/paddingLeft/EditPaddingLeft.tsx
+++ b/src/components/cssEditArea/padding/paddingLeft/EditPaddingLeft.tsx
@@ -1,14 +1,18 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setPadding } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditPaddingLeft = memo(() => {
-    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
-    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent)
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent)
     const dispatch = useAppDispatch()
-    const padding = useAppSelector((state) => state.buttonView.padding)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let padding = cssStates[uid].cssProps.padding
+    if (!padding) {
+        padding = ''
+    }
     const [showTooltipPaddingLeft, setShowTooltipPaddingLeft] = useState(false)
     const getPadding = () => {
         const paddingList = padding.split(' ')
@@ -22,7 +26,6 @@ export const EditPaddingLeft = memo(() => {
         const paddingList = padding.split(' ')
         if (paddingList.length === 4) {
             paddingList[3] = v.toString() + 'px'
-            dispatch(setPadding(paddingList.join(' ')))
             dispatch(
                 saveCurrentCssProps({
                     elementName: selectedElementName,
@@ -32,7 +35,14 @@ export const EditPaddingLeft = memo(() => {
                 })
             )
         } else {
-            dispatch(setPadding(`${padding} ${padding} ${padding} ${padding}`))
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssPropKey: 'padding',
+                    cssPropValue: `${padding} ${padding} ${padding} ${padding}`,
+                })
+            )
         }
     }
     return (

--- a/src/components/cssEditArea/padding/paddingLeft/EditPaddingLeft.tsx
+++ b/src/components/cssEditArea/padding/paddingLeft/EditPaddingLeft.tsx
@@ -2,7 +2,7 @@ import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, 
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
 import { setPadding } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditPaddingLeft = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
@@ -29,14 +29,6 @@ export const EditPaddingLeft = memo(() => {
                     classNames: selectedElementClass,
                     cssPropKey: 'padding',
                     cssPropValue: paddingList.join(' '),
-                })
-            )
-            dispatch(
-                saveCurrentCssCodes({
-                    elementName: selectedElementName,
-                    classNames: selectedElementClass,
-                    cssProp: 'padding',
-                    cssValue: paddingList.join(' '),
                 })
             )
         } else {

--- a/src/components/cssEditArea/padding/paddingRight/EditPaddingRight.tsx
+++ b/src/components/cssEditArea/padding/paddingRight/EditPaddingRight.tsx
@@ -1,14 +1,18 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setPadding } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditPaddingRight = memo(() => {
-    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
-    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent)
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent)
     const dispatch = useAppDispatch()
-    const padding = useAppSelector((state) => state.buttonView.padding)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let padding = cssStates[uid].cssProps.padding
+    if (!padding) {
+        padding = ''
+    }
     const [showTooltipPaddingRight, setShowTooltipPaddingRight] = useState(false)
     const getPadding = () => {
         const paddingList = padding.split(' ')
@@ -22,7 +26,6 @@ export const EditPaddingRight = memo(() => {
         const paddingList = padding.split(' ')
         if (paddingList.length === 4) {
             paddingList[1] = v.toString() + 'px'
-            dispatch(setPadding(paddingList.join(' ')))
             dispatch(
                 saveCurrentCssProps({
                     elementName: selectedElementName,
@@ -32,7 +35,14 @@ export const EditPaddingRight = memo(() => {
                 })
             )
         } else {
-            dispatch(setPadding(`${padding} ${padding} ${padding} ${padding}`))
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssPropKey: 'padding',
+                    cssPropValue: `${padding} ${padding} ${padding} ${padding}`,
+                })
+            )
         }
     }
     return (

--- a/src/components/cssEditArea/padding/paddingRight/EditPaddingRight.tsx
+++ b/src/components/cssEditArea/padding/paddingRight/EditPaddingRight.tsx
@@ -2,7 +2,7 @@ import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, 
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
 import { setPadding } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditPaddingRight = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
@@ -29,14 +29,6 @@ export const EditPaddingRight = memo(() => {
                     classNames: selectedElementClass,
                     cssPropKey: 'padding',
                     cssPropValue: paddingList.join(' '),
-                })
-            )
-            dispatch(
-                saveCurrentCssCodes({
-                    elementName: selectedElementName,
-                    classNames: selectedElementClass,
-                    cssProp: 'padding',
-                    cssValue: paddingList.join(' '),
                 })
             )
         } else {

--- a/src/components/cssEditArea/padding/paddingTop/EditPaddingTop.tsx
+++ b/src/components/cssEditArea/padding/paddingTop/EditPaddingTop.tsx
@@ -2,7 +2,7 @@ import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, 
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
 import { setPadding } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssCodes, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditPaddingTop = memo(() => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
@@ -29,14 +29,6 @@ export const EditPaddingTop = memo(() => {
                     classNames: selectedElementClass,
                     cssPropKey: 'padding',
                     cssPropValue: paddingList.join(' '),
-                })
-            )
-            dispatch(
-                saveCurrentCssCodes({
-                    elementName: selectedElementName,
-                    classNames: selectedElementClass,
-                    cssProp: 'padding',
-                    cssValue: paddingList.join(' '),
                 })
             )
         } else {

--- a/src/components/cssEditArea/padding/paddingTop/EditPaddingTop.tsx
+++ b/src/components/cssEditArea/padding/paddingTop/EditPaddingTop.tsx
@@ -1,14 +1,18 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { memo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../../hooks'
-import { setPadding } from '../../../buttonView/buttonViewSlice'
-import { saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../../pseudoArea/pseudoAreaSlice'
 
 export const EditPaddingTop = memo(() => {
-    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
-    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent)
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent)
     const dispatch = useAppDispatch()
-    const padding = useAppSelector((state) => state.buttonView.padding)
+    const uid = getElementUid(selectedElementName, selectedElementClass)
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
+    let padding = cssStates[uid].cssProps.padding
+    if (!padding) {
+        padding = ''
+    }
     const [showTooltipPaddingTop, setShowTooltipPaddingTop] = useState(false)
     const getPadding = () => {
         const paddingList = padding.split(' ')
@@ -22,7 +26,6 @@ export const EditPaddingTop = memo(() => {
         const paddingList = padding.split(' ')
         if (paddingList.length === 4) {
             paddingList[0] = v.toString() + 'px'
-            dispatch(setPadding(paddingList.join(' ')))
             dispatch(
                 saveCurrentCssProps({
                     elementName: selectedElementName,
@@ -32,7 +35,14 @@ export const EditPaddingTop = memo(() => {
                 })
             )
         } else {
-            dispatch(setPadding(`${padding} ${padding} ${padding} ${padding}`))
+            dispatch(
+                saveCurrentCssProps({
+                    elementName: selectedElementName,
+                    classNames: selectedElementClass,
+                    cssPropKey: 'padding',
+                    cssPropValue: `${padding} ${padding} ${padding} ${padding}`,
+                })
+            )
         }
     }
     return (

--- a/src/components/cssEditArea/width/EditWidth.tsx
+++ b/src/components/cssEditArea/width/EditWidth.tsx
@@ -4,10 +4,10 @@ import { useAppDispatch, useAppSelector } from '../../../hooks'
 import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 
 export const EditWidth = () => {
-    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
-    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
+    const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent)
+    const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent)
     const uid = getElementUid(selectedElementName, selectedElementClass)
-    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
+    const cssStates = useAppSelector((state) => state.pseudoArea.cssStates)
     const [showTooltip, setShowTooltip] = useState(false)
     const dispatch = useAppDispatch()
     let width = cssStates[uid].cssProps.width

--- a/src/components/cssEditArea/width/EditWidth.tsx
+++ b/src/components/cssEditArea/width/EditWidth.tsx
@@ -1,24 +1,21 @@
 import { Flex, Slider, SliderFilledTrack, SliderMark, SliderThumb, SliderTrack, Text, Tooltip } from '@chakra-ui/react'
 import React, { useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
-import { setWidth } from '../../buttonView/buttonViewSlice'
-import { getElementUid, saveCurrentCssCodes, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
+import { getElementUid, saveCurrentCssProps } from '../../pseudoArea/pseudoAreaSlice'
 
 export const EditWidth = () => {
     const selectedElementClass = useAppSelector((state) => state.pseudoArea.elementClassSelectedCurrent) //現在の選択中のelementClass
     const selectedElementName = useAppSelector((state) => state.pseudoArea.elementNameSelectedCurrent) //現在の選択中のelementName
-    const [showTooltip, setShowTooltip] = useState(false)
-    const dispatch = useAppDispatch()
-    // TODO:↓↓buttonViewから取得しているが、それだと、例えばmain -> beforeと切り替えたときに、以前のプロパティを（見た目上）
-    // 保持したままになってしまうので、pseudoSliceから取得し、無ければ初期値を適用する処理が必要
-    const width = useAppSelector((state) => state.buttonView.width)
     const uid = getElementUid(selectedElementName, selectedElementClass)
     const cssStates = useAppSelector((state) => state.pseudoArea.cssStates) //現在のcssState
+    const [showTooltip, setShowTooltip] = useState(false)
+    const dispatch = useAppDispatch()
+    let width = cssStates[uid].cssProps.width
+    if (!width) {
+        width = ''
+    }
     const displayWidth = cssStates[uid].customAreaDisplay.width
-
     const onChangeValue = (v: number) => {
-        dispatch(setWidth(v.toString() + 'px'))
-        // saveCurrentCssPropsにて現在の↑↑で更新された現在のCSSプロパティを入れると非同期処理の問題でスライドバーがガタつく為、新たに作成して代入している。
         dispatch(
             saveCurrentCssProps({
                 elementName: selectedElementName,
@@ -27,16 +24,7 @@ export const EditWidth = () => {
                 cssPropValue: v.toString() + 'px',
             })
         )
-        dispatch(
-            saveCurrentCssCodes({
-                elementName: selectedElementName,
-                classNames: selectedElementClass,
-                cssProp: 'width',
-                cssValue: v.toString() + 'px',
-            })
-        )
     }
-
     return (
         <>
             {displayWidth ? (

--- a/src/components/pseudoArea/PseudoButton.tsx
+++ b/src/components/pseudoArea/PseudoButton.tsx
@@ -3,22 +3,6 @@ import { ActionCreatorWithPayload } from '@reduxjs/toolkit'
 import React, { memo, useEffect, useRef } from 'react'
 import { useAppDispatch, useAppSelector } from '../../hooks'
 import {
-    setBackgroundColor,
-    setBorder,
-    setBorderColor,
-    setBorderRadius,
-    setBorderStyle,
-    setBorderWidth,
-    setColor,
-    setDisplay,
-    setFontSize,
-    setHeight,
-    setPadding,
-    setTextDecoration,
-    setWidth,
-} from '../buttonView/buttonViewSlice'
-
-import {
     removeElementClassSelectedCurrent,
     createNewCssStates,
     setElementClassSelectedCurrent,
@@ -80,22 +64,6 @@ export const PseudoButton = memo((props: propsType) => {
         if (uid in cssStates === false) {
             return
         }
-
-        // 新しい選択先のcssStateをロードする
-        // TODO:コイツも将来的にpseudo sliceに統合してbutton sliceを削除する
-        dispatch(setColor(cssStates[uid].cssProps.color))
-        dispatch(setBackgroundColor(cssStates[uid].cssProps.backgroundColor))
-        dispatch(setBorder(cssStates[uid].cssProps.border))
-        dispatch(setPadding(cssStates[uid].cssProps.padding))
-        dispatch(setTextDecoration(cssStates[uid].cssProps.textDecoration))
-        dispatch(setDisplay(cssStates[uid].cssProps.display))
-        dispatch(setFontSize(cssStates[uid].cssProps.fontSize))
-        dispatch(setBorderColor(cssStates[uid].cssProps.borderColor))
-        dispatch(setBorderRadius(cssStates[uid].cssProps.borderRadius))
-        dispatch(setBorderStyle(cssStates[uid].cssProps.borderStyle))
-        dispatch(setBorderWidth(cssStates[uid].cssProps.borderWidth))
-        dispatch(setWidth(cssStates[uid].cssProps.width))
-        dispatch(setHeight(cssStates[uid].cssProps.height))
     }, [cssStates])
     return (
         <>

--- a/src/components/pseudoArea/pseudoAreaSlice.ts
+++ b/src/components/pseudoArea/pseudoAreaSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice, current, PayloadAction } from '@reduxjs/toolkit'
 import { getStateType } from '../../store'
 import { buttonInitialState } from '../buttonView/buttonViewSlice'
-import { cssCustomAreaDisplay, cssCustomAreaType } from '../cssCustomArea/cssCustomAreaSlice'
+import { cssCustomAreaDisplay } from '../cssCustomArea/cssCustomAreaSlice'
 
 type arrayType = {
     [prop: string]: statesType
@@ -13,20 +13,17 @@ type statesType = {
     cssProps: {
         [prop: string]: string
     }
-    customAreaDisplay: cssCustomAreaType
-    cssCodes: {
-        [prop: string]: string
+    customAreaDisplay: {
+        [prop: string]: boolean
     }
 }
 
 const initCustomAreaDisplay = { ...cssCustomAreaDisplay }
-const initCssProps = { ...buttonInitialState }
 const initCssState: statesType = {
     elementName: 'Main', // main, before, after, etc
     classNames: [], // hover, focus, active, etc...(CSSの仕組み上、複合する可能性あり['hover', 'focus']みたいな感じ)
-    cssProps: initCssProps,
+    cssProps: {}, // {width: '100px', height: '100px' ...}
     customAreaDisplay: initCustomAreaDisplay,
-    cssCodes: {}, // {width: '100px', height: '100px' ...}
 }
 
 const initCssStates: arrayType = {
@@ -198,32 +195,7 @@ export const pseudoAreaSlice = createSlice({
             }
             state.cssStates[uid] = newCssState
         },
-        saveCurrentCssCodes: (
-            state,
-            action: PayloadAction<{
-                elementName: string
-                classNames: string[]
-                cssProp: string
-                cssValue: string
-            }>
-        ) => {
-            const elementName = action.payload.elementName
-            const classNames = action.payload.classNames
-            const cssProp = action.payload.cssProp
-            const cssValue = action.payload.cssValue
-
-            const uid = getElementUid(elementName, classNames)
-            const cssState = current(state.cssStates)[uid]
-            const newCssState = {
-                ...cssState,
-                cssCodes: {
-                    ...cssState.cssCodes,
-                    [cssProp]: cssValue,
-                },
-            }
-            state.cssStates[uid] = newCssState
-        },
-        removeCurrentCssCodes: (
+        removeCurrentCssProps: (
             state,
             action: PayloadAction<{
                 elementName: string
@@ -237,13 +209,13 @@ export const pseudoAreaSlice = createSlice({
 
             const uid = getElementUid(elementName, classNames)
             const cssState = current(state.cssStates)[uid]
-            const newCssCodes = {
-                ...cssState.cssCodes,
+            const newCssProps = {
+                ...cssState.cssProps,
             }
-            delete newCssCodes[cssProp]
+            delete newCssProps[cssProp]
             const newCssState = {
                 ...cssState,
-                cssCodes: newCssCodes,
+                cssProps: newCssProps,
             }
             state.cssStates[uid] = newCssState
         },
@@ -293,8 +265,7 @@ export const {
     createNewCssStates,
     saveCustomAreaDisplay,
     saveCurrentCssProps,
-    saveCurrentCssCodes,
-    removeCurrentCssCodes,
+    removeCurrentCssProps,
     setIsActiveMain,
     setIsActiveBefore,
     setIsActiveAfter,

--- a/src/components/templates/ButtonTemplate.tsx
+++ b/src/components/templates/ButtonTemplate.tsx
@@ -2,12 +2,7 @@ import React from 'react'
 import { css, CSSObject } from '@emotion/react'
 import { Flex } from '@chakra-ui/react'
 import { useAppDispatch } from '../../hooks'
-import {
-    createNewCssStates,
-    saveCurrentCssCodes,
-    saveCurrentCssProps,
-    saveCustomAreaDisplay,
-} from '../pseudoArea/pseudoAreaSlice'
+import { createNewCssStates, saveCurrentCssProps, saveCustomAreaDisplay } from '../pseudoArea/pseudoAreaSlice'
 
 type cssStyles = {
     width?: string
@@ -22,8 +17,8 @@ type cssStyles = {
 type buttonStyles =
     | cssStyles
     | {
-          '&hover'?: cssStyles
-          '&active'?: cssStyles
+          '&:hover'?: cssStyles
+          '&:active'?: cssStyles
       }
 
 type newArray = {
@@ -77,14 +72,6 @@ export const ButtonTemplate = (buttonStyle: buttonStyles) => {
                             classNames: classNames,
                             cssPropKey: cssPropKey,
                             cssPropValue: cssPropValue,
-                        })
-                    )
-                    dispatch(
-                        saveCurrentCssCodes({
-                            elementName: elementName,
-                            classNames: classNames,
-                            cssProp: cssPropKey,
-                            cssValue: cssPropValue,
                         })
                     )
                     dispatch(

--- a/src/types/cssTypes.ts
+++ b/src/types/cssTypes.ts
@@ -13,3 +13,6 @@ export type cssTypes = {
     width: string
     height: string
 }
+export type arrayType = {
+    [prop: string]: string
+}


### PR DESCRIPTION
button view slice -> pseudo sliceに引っ越し完了
ただ、template button でbutton view sliceが使われていて、button view slice自体を削除すると
手間が多いのと、未対応プロパティがわからなくなるので消しはせずいったんこのままで

template button が対応したら削除します